### PR TITLE
Big-bang vs bit-by-bit porting

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -46,7 +46,12 @@ api:
 	@echo "Build API docs...done."
 
 
-html: api
+html: api html-only
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(DEST)/html
+	@echo
+	@echo "Build finished. The HTML pages are in build/html."
+
+html-only:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(DEST)/html
 	@echo
 	@echo "Build finished. The HTML pages are in build/html."

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -47,9 +47,6 @@ api:
 
 
 html: api html-only
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(DEST)/html
-	@echo
-	@echo "Build finished. The HTML pages are in build/html."
 
 html-only:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(DEST)/html

--- a/doc/source/skips/5-v2-port-procedure.md
+++ b/doc/source/skips/5-v2-port-procedure.md
@@ -58,7 +58,7 @@ We could also call this approach "move-and-edit".
 #### Bit-by-bit
 
 This is our approach at time of writing. For each Skimage2-related change, we
-copy the implementation of the relevant functions (etc) to the `src/_skmage2`
+move the implementation of the relevant functions (etc) to the `src/_skmage2`
 tree, along with the relevant tests, and make suitable wrappers that import and modify that implementation in the `src/skimage` tree.
 
 Thus the `_skimage2` namespace fills up gradually, as we do the migration of the API and other code.

--- a/doc/source/skips/5-v2-port-procedure.md
+++ b/doc/source/skips/5-v2-port-procedure.md
@@ -317,7 +317,7 @@ checks, we will miss necessary changes for `skimage2`.
 This does seem like it could be a problem, but what kind of problems can we predict?
 
 It seems to me there are two different sorts of porting problems.  These are
-*inconsistencies* and *missed opportunity*.
+*inconsistencies* and *missed opportunities*.
 
 1. We make some policy change, such as shifting to enforce `ij` ordering for
    coordinates, but we miss this change in a `skimage2` function, making
@@ -340,12 +340,24 @@ of while we were doing the port (it's a new change) and b) have also forgotten t
 That brings us back to *inconsistencies*.  These are considerably more
 serious, and we should be careful to avoid them.  The question is, are per-PR
 checks for all relevant changes the correct way to avoid inconsistencies?
-Again, returning to the coordinate system changes — there are many such changes.  It would not be practical to enforce the rule that any PR must implement all possible related changes — for example — all changes to `ij` interpretation.   To do so would be to condemn us to very large PRs that are difficult to review.   If we do not have that rule, that reduces of the value of the per-PR checks for every possible `skimage2` change.   It seems to me that the more practical route is confirming that the changes in any give PR do implement some part of the route to the new API, and note the remaining parts (as discovered and elaborated during the PR) in the porting list.
+Again, returning to the coordinate system changes — there are many such
+changes.  It would not be practical to enforce the rule that any PR must
+implement all possible related changes — for example — all changes to `ij`
+interpretation.   To do so would be to condemn us to very large PRs that are
+difficult to review.   If we do not have that rule, that reduces of the value
+of the per-PR checks for every possible `skimage2` change.   It seems to me
+that the more practical route is confirming that the changes in any given PR
+do implement some part of the route to the new API, and note the remaining
+parts (as discovered and elaborated during the PR) in the porting list.
 
 I (MB) would therefore argue that the more practical route to avoid
 inconsistent behavior is to do regular (perhaps per PR) review and updating of
 the porting list, rather than attempting to enforce full implementation in
-each PR.  And that, if we do enforce full review for any possible `skimage2` in each PR, that will have the effect of slowing us down, and making it more difficult to iterate through the changes.
+each PR.  We then, of course, go back through the codebase, towards the end of
+the migration, to confirm and sign off relevant changes in the porting list.
+On the other hand, if we do enforce full review for any possible `skimage2` in
+each PR, that will have the effect of slowing us down, and making it more
+difficult to iterate through the changes.
 
 (detailed-description)=
 

--- a/doc/source/skips/5-v2-port-procedure.md
+++ b/doc/source/skips/5-v2-port-procedure.md
@@ -355,9 +355,9 @@ inconsistent behavior is to do regular (perhaps per PR) review and updating of
 the porting list, rather than attempting to enforce full implementation in
 each PR.  We then, of course, go back through the codebase, towards the end of
 the migration, to confirm and sign off relevant changes in the porting list.
-On the other hand, if we do enforce full review for any possible `skimage2` in
-each PR, that will have the effect of slowing us down, and making it more
-difficult to iterate through the changes.
+On the other hand, if we do enforce full review for any possible `skimage2`
+change in each PR, that will have the effect of slowing us down, and making it
+more difficult to iterate through the changes.
 
 (detailed-description)=
 

--- a/doc/source/skips/5-v2-port-procedure.md
+++ b/doc/source/skips/5-v2-port-procedure.md
@@ -1,0 +1,105 @@
+(skip5-v2-port_procedure)=
+
+# SKIP 5 — Skimage2 porting procedure
+
+:Author: Matthew Brett
+:Status: Draft
+:Type: Standards Track
+:Created: 2026-03-27
+:Resolved: <null>
+:Resolution: <null>
+:Version effective: <null>
+
+## Abstract
+
+We describe the general procedure for porting the code in `skimage` to the Skimage2 namespace.
+
+## Motivation and Scope
+
+We have already decided to have three namespaces:
+
+- `skimage` (housing the Skimage1 API)
+- `_skimage2` (housing the evolving Skimage2 API)
+- `skimage2` (imports `_skimage2` and adds FutureWarning. We won't discuss that further here.
+
+`skimage` can import directly from `_skimage2`, but `_skimage2` cannot import directly from `skimage`; if it does need `skimage` routines, it must do local (deferred, inline) imports, inside functions or methods, to avoid circular imports.
+
+We have also agreed that we should _copy_ tests from `skimage` (e.g. `tests/skimage/transform/tests` to `tests/skimage2/transform/tests` as we port.
+
+At some point, we will need a full Skimage2 implementation in `_skimage2`, with a full set of tests exercising that namespace. There will be a few functions and modules that will stay in `skimage`, such as everything in `skimage/future`, but otherwise, all or nearly all code in `skimage`
+
+This section describes the need for the proposed change. It should
+describe the existing problem, who it affects, what it is trying to
+solve, and why. This section should explicitly address the scope of and
+key requirements for the proposed change.
+
+## Detailed description
+
+This section should provide a detailed description of the proposed
+change. It should include examples of how the new functionality would be
+used, intended use-cases, and pseudocode illustrating its use.
+
+## Related Work
+
+This section should list relevant and/or similar technologies, possibly
+in other libraries. It does not need to be comprehensive, just list the
+major examples of prior and relevant art.
+
+## Implementation
+
+This section lists the major steps required to implement the SKIP. Where
+possible, it should be noted where one step is dependent on another, and
+which steps may be optionally omitted. Where it makes sense, each step
+should include a link related pull requests as the implementation
+progresses.
+
+Any pull requests or developmt branches containing work on this SKIP
+should be linked to from here. (A SKIP does not need to be implemented
+in a single pull request if it makes sense to implement it in discrete
+phases).
+
+## Backward compatibility
+
+This section describes the ways in which the SKIP breaks backward
+compatibility.
+
+## Alternatives
+
+If there were any alternative solutions to solving the same problem,
+they should be discussed here, along with a justification for the chosen
+approach.
+
+## Discussion
+
+This section may just be a bullet list including links to any
+discussions regarding the SKIP, but could also contain additional
+comments about that discussion:
+
+- This includes links to discussion forum threads or relevant GitHub
+  discussions.
+
+## References and Footnotes
+
+All SKIPs should be declared as dedicated to the public domain with the
+CC0 license[^1], as in [Copyright](copyright-section), below, with attribution
+encouraged with CC0+BY [^2].
+
+(copyright-section)=
+
+## Copyright
+
+This document is dedicated to the public domain with the Creative
+Commons CC0 license[^3]. Attribution to this source is encouraged where
+appropriate, as per CC0+BY[^4].
+
+[^1]:
+    CC0 1.0 Universal (CC0 1.0) Public Domain Dedication,
+    <https://creativecommons.org/publicdomain/zero/1.0/>
+
+[^2]: <https://dancohen.org/2013/11/26/cc0-by/>
+
+[^3]:
+    CC0 1.0 Universal (CC0 1.0) Public Domain Dedication,
+    <https://creativecommons.org/publicdomain/zero/1.0/>
+
+[^4]: <https://dancohen.org/2013/11/26/cc0-by/>

--- a/doc/source/skips/5-v2-port-procedure.md
+++ b/doc/source/skips/5-v2-port-procedure.md
@@ -1,6 +1,6 @@
 (skip5-v2-port_procedure)=
 
-# SKIP 5 — Skimage2 porting procedure
+# SKIP 5 — scikit-image v2 porting procedure
 
 :Author: Matthew Brett
 :Status: Draft
@@ -12,32 +12,51 @@
 
 ## Abstract
 
-We describe the general procedure for porting the code in `skimage` to the Skimage2 namespace.
+We describe the general procedure for porting the code in `skimage` to the scikit-image v2 namespace.
 
 ## Motivation and Scope
 
 ### Background
 
-We have already decided to have three namespaces:
+#### Decisions agreed before this Skip
 
-- `skimage` (housing the Skimage1 API)
-- `_skimage2` (housing the evolving Skimage2 API)
-- `skimage2` (imports `_skimage2` and adds FutureWarning. We won't discuss that further here.
+* We will have three namespaces:
 
-`skimage` can import directly from `_skimage2`, but `_skimage2` cannot import directly from `skimage`; if it does need `skimage` routines, it must do local (deferred, inline) imports, inside functions or methods, to avoid circular imports.
+  - `skimage` (housing the Skimage1 API)
+  - `_skimage2` (housing the evolving scikit-image v2 API)
+  - `skimage2` (imports `_skimage2` and adds FutureWarning. We won't discuss that further here.
 
-We have also agreed that we should _copy_ tests from `skimage` (e.g. `tests/skimage/transform/tests` to `tests/skimage2/transform/tests`) as we port.
+  For rationale for this structure, see [^import-structure].
 
-At some point, we will need a full Skimage2 implementation in `_skimage2`, with a full set of tests exercising that namespace. There will be a few functions and modules that will stay in `skimage`, such as everything in `skimage/future`, but otherwise, all or nearly all code in `skimage` will move in some form to `_skimage2`.
+* We agreed that we should _copy_ tests from `skimage` (e.g.
+  `tests/skimage/transform/tests` to `tests/skimage2/transform/tests`) as we
+  port.
 
-### Big-bang or bit-by-bit
+[^import-structure]: `skimage` can import directly from `_skimage2`, but `_skimage2` cannot import
+  directly from `skimage`; if it does need `skimage` routines, it must do local
+  (deferred, inline) imports, inside functions or methods, to avoid circular
+  imports.
 
-There are two potential approaches to this problem.
+  This structure is to allow `skimage` to import from the scikit-image v2
+  namespace without triggering a warning.  Conversely, `skimage2` exists only
+  to trigger a `FutureWarning` for any imports from `_skimage2`.
+
+#### Endpoint
+
+At some point, we will need a full scikit-image v2 implementation in
+`_skimage2`, with a full set of tests exercising that namespace. There will be
+a few functions and modules that will stay in `skimage`, such as everything in
+`skimage/future`, but otherwise, all or nearly all code in `skimage` will move
+in some form to `_skimage2`.
+
+### Porting strategies
+
+There are two potential approaches to this problem, that we will call *big-bang* and *bit-by-bit*.
 
 #### Big-bang
 
 One implementation we will call "big-bang". Here we move all the current
-`skimage` implementations, that will have versions in Skimage2, into the
+`skimage` implementations, that will have versions in scikit-image v2, into the
 `_skimage2` namespace. We import the `_skimage2` implementations back into the
 `skimage` namespace, while preserving the current `skimage` wrappers for
 already ported code.
@@ -50,14 +69,14 @@ section](detailed-description) below.
 This leaves us with a complete `_skimage2` namespace, but where we have yet to
 complete the API and other changes in that namespace.
 
-After this, all Skimage2 changes take place in the `src/_skimage2` and
+After this, all scikit-image v2 changes take place in the `src/_skimage2` and
 `tests/_skimage2` trees.
 
 We could also call this approach "move-and-edit".
 
 #### Bit-by-bit
 
-This is our approach at time of writing. For each Skimage2-related change, we
+This is our approach at time of writing. For each scikit-image v2-related change, we
 move the implementation of the relevant functions (etc) to the `src/_skmage2`
 tree, along with the relevant tests, and make suitable wrappers that import and modify that implementation in the `src/skimage` tree.
 
@@ -69,24 +88,32 @@ First let's start with the general ideas, and then get down to specifics.
 
 #### Bit-by-bit as migration log
 
-One benefit for the bit-by-bit approach is, if we do the changes in
-a particular way, then we can reasonably believe that all the code /APIs in
+We can add an extra constraint to the bit-by-bit approach, which is to ensure
+that we only ever move functions to `_skimage2` where we are confident that the
+code will continue to be about the same, and with the same API, as for
+scikit-image v2. That is, in moving any code, we assert that this code is
+scikit-image v2 ready.
+
+Call this variant - *bit-by-bit-and-certify*, or BBBC for short.
+
+If we use BBBC then we can reasonably believe that all the code /APIs in
 `src/_skimage2` is at least something like the code / APIs in the eventual
-first Skimage2 release.
+first scikit-image v2 release.
 
-The "particular way" is one where we only ever move functions to `_skimage2` where we are confident that the code will continue to be about the same, and with the same API, as for Skimage2. That is, in moving any code, we assert that this code is Skimage2 ready.
-
-The idea here is that we not only make partial Skimage2 changes, but we do all
-likely Skimage2 changes. In that way, we can use the code in `_skimage2` (as
-compared to that in `skimage`) as a record of what changes we have done in the
-migration. Call this the migration-log function of the bit-by-bit approach.
-
-#### Bit-by-bit as partial guarantee of future API
+The idea here is that, as we submit PRs, we not only make partial scikit-image
+v2 changes, but we do all likely scikit-image v2 changes. In that way, we can
+use the code in `_skimage2` (as compared to that in `skimage`) as a record of
+what changes we have done in the migration. Call this the migration-log
+function of the bit-by-bit approach.
 
 With the big-bang approach, we can't initially tell users to start using
-`_skimage2` code, with the expectation that the code will, in fact, have the API of Skimage2 — because, at first, the code will be a still changing version of `skimage`.
+`_skimage2` code, with the expectation that the code will, in fact, have the
+API of scikit-image v2 — because, at first, the code will be a still changing
+version of `skimage`.
 
-Of course, we could keep the `_skimage2` directory under wraps until it is mostly complete. Or we could advertise only a few parts of the `_skimage2` / `skimage2` namespace.
+Of course, we could keep the `_skimage2` directory under wraps until it is
+mostly complete. Or we could advertise only a few parts of the `_skimage2`
+/ `skimage2` namespace.
 
 #### Migration in practice
 
@@ -98,12 +125,12 @@ The `fake` module might look something like this:
 
 ```python
 def foo(a, b, c):
-    "No Skimage2 changes yet proposed"
+    "No scikit-image v2 changes yet proposed"
     return bar(baz(a, b), c)
 
 def bar(d, f=None):
-    "Planned Skimage2 API changes"
-    return baz(a ** 2, f)
+    "Planned scikit-image v2 API changes"
+    return baz(d ** 2, f)
 
 def baz(g, h)
     return g * 2 + h
@@ -112,49 +139,55 @@ def baz(g, h)
 `test_fake.py` has:
 
 ```python
-from _skimage.fakepkg.fake import foo, bar, baz
+from skimage.fakepkg.fake import foo, bar, baz
 
 def test_foo():
-    # No planned Skimage2 change.
+    # No planned scikit-image v2 change.
     assert foo(1, 2, 3)
 
 def test_bar():
-    # Planned Skimage2 change of behavior.
+    # Planned scikit-image v2 change of behavior.
     assert bar(1)
     assert bar(1, 2) == 3
 
 def test_baz():
-    # No planned Skimage2 change of behavior.
+    # No planned scikit-image v2 change of behavior.
     assert baz(1, 2) == 4
 ```
 
-Let us say we want to do a PR to change the default value of `bar` from None
+Let us say we want to do a PR to change the default value of `bar` above from None
 to 10.
 
-With the bit-by-bit approach, we have some work to do. First we have to
-identify what will go in the PR. On analysis we do need to move over the
-`bar` function, and the `baz` function, but we don't need the `foo` function. So we edit `src/_skimage2/fakepkg/fake.py` to have only:
+With the BBBC approach, and this example, we will have to *disentangle* the
+ported functions and their tests, to work out what will go into the `_skimage2`
+namespace.  Call this — the *disentangle problem*.
+
+Disentangling involves identifying what will go in the PR. On analysis we do
+need to move over the `bar` function, and the `baz` function, but we don't need
+the `foo` function.  Or perhaps, perhaps we know the `foo` function is due for
+more scikit-image v2 changes, that we don't want to do at the moment.   So we
+edit `src/_skimage2/fakepkg/fake.py` to have only:
 
 ```python
 def bar(d, f=10):
-    "Planned Skimage2 API changed"
-    return baz(a ** 2, f)
+    "Planned scikit-image v2 API changed"
+    return baz(d ** 2, f)
 
 def baz(g, h)
     return g * 2 + h
 ```
 
-Leaving `src/skimage/fakepkg/fake.py`:
+This leaves `src/skimage/fakepkg/fake.py` behind:
 
 ```python
-from _skimage2.fakepkg.fake import bar, baz
+from _skimage2.fakepkg.fake import bar2, baz
 
 @migration_warning('Default value of f changed in skimage2 from None to 10')
 def bar(d, f=None):
-    return bar(d, f)
+    return bar2(d, f)
 
 def foo(a, b, c):
-    "No Skimage2 changes yet proposed"
+    "No scikit-image v2 changes yet proposed"
     return bar(baz(a, b), c)
 ```
 
@@ -166,12 +199,12 @@ We also might want to split up the test function:
 from _skimage2.fakepkg.fake import bar, baz
 
 def test_bar():
-    # Planned Skimage2 change of behavior.
+    # Planned scikit-image v2 change of behavior.
     assert bar(1)
     assert bar(1, 2) == 3
 
 def test_baz():
-    # No planned Skimage2 change of behavior.
+    # No planned scikit-image v2 change of behavior.
     assert baz(1, 2) == 4
 ```
 
@@ -181,30 +214,35 @@ def test_baz():
 from _skimage.fakepkg.fake import foo
 
 def test_foo():
-    # No planned Skimage2 change.
+    # No planned scikit-image v2 change.
     assert foo(1, 2, 3)
 ```
 
 There are a few problems here.
 
-- We were tempted to first — analyze what code was using what, and then split
-  up files, increasing work.
+- The Certify aspect of the BBBC process requires to analyze what code was
+  using what, and then split up files, increasing work.  We do not need to do
+  this analysis or splitting of files for the Big-Bang procedure.
 - We had to think about where our imports are coming from.
 - We are left, towards the end of the porting process, with the task of pulling
   the bits of the file still in `skimage` back into the code in `_skimage2`.
 - If we want to maintain the migration-log benefit of bit-by-bit, we have to
   think about which functions are fully `_skimage2`-ready, and which are not.
-  For example, will we be changing `baz` or `foo` in Skimage2? This adds extra
+  For example, will we be changing `baz` or `foo` in scikit-image v2? This adds extra
   complexity to the port process, and review.
 
 In contrast, it is more straightforward to do the port with the big-bang
-approach. We already have copied tests
-(`tests/_skimage2/fakepkg/tests/test_fake.py`, so we just modify that
-appropriately, leaving the `skimage` version intact. We don't have to split up the `fake.py` function, or think about which functions are fully Skimage2-ready, we concentrate on the changes of interest to us. We do, of course, have to write suitable wrappers or alternative implementations in the `skimage` namespace, as before.
+approach. We already have copied all the tests, in one big-bang step.  So we already have a complete
+`tests/_skimage2/fakepkg/tests/test_fake.py`.  We just modify that
+appropriately, leaving the `skimage` version intact. We don't have to split up
+the `fake.py` function, or think about which functions are fully scikit-image
+v2-ready, we concentrate on the changes of interest to us. We do, of course,
+have to write suitable wrappers or alternative implementations in the `skimage`
+namespace, as before.
 
 ### On the migration-log idea
 
-Given there are development costs for the bit-by-bit implementation, how great are the benefits, in particular, for the migration-log idea.
+Gwiven there are development costs for the bit-by-bit implementation, how great are the benefits, in particular, for the migration-log idea.
 
 The question has to be asked in relation to:
 
@@ -223,16 +261,49 @@ instances, for example with AI, and dealing with those? We will likely find
 it easier to whole-code-base screening and changes when all the code is in one
 `_skimage2` tree, rather than broken up into `_skimage2` and `skimage`.
 
-We do have alternative methods of tracking the ports. For example, we could
-maintain a checklist like that in
+#### Altnerative ways of tracking migration
+
+We should in any case, maintain a checklist like that in
 <https://github.com/scikit-image/scikit-image/wiki/API-changes-for-skimage2>.
-We could make it part of the PR process, maintaining that list. I suppose one
-could argue that the partially filled `_skimage2` is a better log, but it is,
-at least, not as readable.
+We could make it part of the PR process, maintaining that list.
 
-Lastly — one could argue that, by forcing reviewers to think about whether all Skimage2 changes have been done, we can make sure we don't forget to make changes that occur to us as we port — but this begs the question of whether we should go looking for Skimage2 changes, or treat the default as "leave-as-is", on the basis that the greater the volume of changes, the higher the risk that Skimage1 users will not in fact migrate.
+Note that, no matter what approach we take, any changed APIs in `_skimage2`
+*must* have wrappers or alternative implmentations in `skimage`.
 
-Is the agreed (and debated, and updated) checklist page a better record of the changes we want to make? One that might serve as a brake on lower-value changes? And can we reassure ourselves we are ready for Skimage2 by careful review of the whole code-base (in `_skimage2`) when we are nearer release?
+If we use the big-bang approach, these wrappers and implementations provide
+a full migration log, because any function that is, as yet, unmodified, will be
+directly imported and not modified in the `skimage` tree.
+
+Specifically, and for example, we can see what has been ported by looking at
+the `skmage/transform/__init__.py` module, as this will have something on the lines of:
+
+```python
+from _skimage2.transform import *
+import _skimage2.transform as sk2t
+
+# Any API-change wrappers below.
+@migration_warning('Default value of f changed in skimage2 from None to 10')
+def somefunction(d, f=None):
+    # Some processing
+    return sk2t.somefunction(d, f)
+
+# And so on.
+```
+
+Lastly, I wonder whether the Certify requirement in the BBBC approach, will
+bias us to choose to make scikit-image v2 changes that we would not do (and
+should not do) without the Certify apporach. I suspect we'll find ourselves
+trying to think of any possible change we could make for scikit-image v2 in
+every PR, and I suspect that will lead to us making more changes, some of which
+will prove to 50-50 calls that probably aren't worth the disruption. This is
+a speculation that the bit-by-bit-certify process will mean that the default
+moves further towards if-in-doubt-change, and that is not desirable.
+
+Is the agreed (and debated, and updated) checklist page a better record of the
+changes we want to make? One that might serve as a brake on lower-value
+changes? And can we reassure ourselves we are ready for scikit-image v2 by
+careful review of the whole code-base (in `_skimage2`) when we are nearer
+release?
 
 (detailed-description)=
 
@@ -267,7 +338,7 @@ which steps may be optionally omitted. Where it makes sense, each step
 should include a link related pull requests as the implementation
 progresses.
 
-Any pull requests or developmt branches containing work on this SKIP
+Any pull requests or development branches containing work on this SKIP
 should be linked to from here. (A SKIP does not need to be implemented
 in a single pull request if it makes sense to implement it in discrete
 phases).

--- a/doc/source/skips/5-v2-port-procedure.md
+++ b/doc/source/skips/5-v2-port-procedure.md
@@ -190,8 +190,8 @@ There are a few problems here.
 - We were tempted to first — analyze what code was using what, and then split
   up files, increasing work.
 - We had to think about where our imports are coming from.
-- We are left, towards the end of the porting process, of pulling the bits of
-  the file still in `skimage` back into the code in `_skimage2`.
+- We are left, towards the end of the porting process, with the task of pulling
+  the bits of the file still in `skimage` back into the code in `_skimage2`.
 - If we want to maintain the migration-log benefit of bit-by-bit, we have to
   think about which functions are fully `_skimage2`-ready, and which are not.
   For example, will we be changing `baz` or `foo` in Skimage2? This adds extra

--- a/doc/source/skips/5-v2-port-procedure.md
+++ b/doc/source/skips/5-v2-port-procedure.md
@@ -16,6 +16,8 @@ We describe the general procedure for porting the code in `skimage` to the Skima
 
 ## Motivation and Scope
 
+### Background
+
 We have already decided to have three namespaces:
 
 - `skimage` (housing the Skimage1 API)
@@ -28,16 +30,230 @@ We have also agreed that we should _copy_ tests from `skimage` (e.g. `tests/skim
 
 At some point, we will need a full Skimage2 implementation in `_skimage2`, with a full set of tests exercising that namespace. There will be a few functions and modules that will stay in `skimage`, such as everything in `skimage/future`, but otherwise, all or nearly all code in `skimage`
 
-This section describes the need for the proposed change. It should
-describe the existing problem, who it affects, what it is trying to
-solve, and why. This section should explicitly address the scope of and
-key requirements for the proposed change.
+### Big-bang or bit-by-bit
+
+There are two potential approaches to this problem.
+
+#### Big-bang
+
+One implementation we will call "big-bang".  Here we move all the current
+`skimage` implementations, that will have versions in Skimage2, into the
+`_skimage` namespace.  We import the `_skimage2` implementations back into the
+`skimage` namespace, while preserving the current `skimage` wrappers for
+already ported code.
+
+We also copy all tests from `tests/skimage` to `tests/_skimage2`
+
+For more details in the procedure, see the [detailed description
+section](detailed-description) below.
+
+This leaves us with a complete `_skimage` namespace, but where we have yet to
+complete the API and other changes in that namespace.
+
+After this, all Skimage2 changes take place in the `src/_skimage2` and
+`tests/_skimage2` trees.
+
+We could also call this approach "move-and-edit".
+
+#### Bit-by-bit
+
+This is our approach at time of writing.  For each Skimage2-related change, we
+copy the implementation of the relevant functions (etc) to the `src/_skmage2`
+tree, along with the relevant tests, and make suitable wrappers that import and modify that implementation in the `src/skimage` tree.
+
+Thus the `_skimage2` namespace fills up gradually, as we do the migration of the API and other code.
+
+### Benefits and disbenefits from the approaches
+
+First let's start with the general ideas, and then get down to specifics.
+
+#### Bit-by-bit as migration log
+
+One benefit for the bit-by-bit approach is, if we do the changes in
+a particular way, then we can reasonably believe that all the code /APIs in
+`src/_skimage2` is at least something like the code / APIs in the eventual
+first Skimage2 release.
+
+The "particular way" is one where we only ever move functions to `_skimage2` where we are confident that the code will continue to be about the same, and with the same API, as for Skimage2.  That is, in moving any code, we assert that this code is Skimage2 ready.
+
+The idea here is that we not only make partial Skimage2 changes, but we do all
+likely Skimage2 changes.  In that way, we can use the code in `_skimage2` (as
+compared to that in `skimage`) as a record of what changes we have done in the
+migration.  Call this the migration-log function of the bit-by-bit approach.
+
+#### Bit-by-bit as partial guarantee of future API
+
+With the big-bang approach, we can't initially tell users to start using
+`_skimage2` code, with the expectation that the code will, in fact, have the API of Skimage2 — because, at first, the code will be a still changing version of `skimage`.
+
+Of course, we could keep the `_skimage2` directory under wraps until it is mostly complete.   Or we could advertise only a few parts of the `_skimage2` / `skimage2` namespace.
+
+#### Migration in practice
+
+Let's first consider the bit-by-bit approach, and some fake module `fake` in
+`src/skimage/fakepkg/fake.py`.   Let's assume the tests are in a single test
+module: `tests/skimage/fakepkg/tests/test_fake.py`.
+
+The `fake` module might look something like this:
+
+```python
+def foo(a, b, c):
+    "No Skimage2 changes yet proposed"
+    return bar(baz(a, b), c)
+
+def bar(d, f=None):
+    "Planned Skimage2 API changes"
+    return baz(a ** 2, f)
+
+def baz(g, h)
+    return g * 2 + h
+```
+
+`test_fake.py` has:
+
+```python
+from _skimage.fakepkg.fake import foo, bar, baz
+
+def test_foo():
+    # No planned Skimage2 change.
+    assert foo(1, 2, 3)
+
+def test_bar():
+    # Planned Skimage2 change of behavior.
+    assert bar(1)
+    assert bar(1, 2) == 3
+
+def test_baz():
+    # No planned Skimage2 change of behavior.
+    assert baz(1, 2) == 4
+```
+
+Let us say we want to do a PR to change the default value of `bar` from None
+to 10.
+
+With the bit-by-bit approach, we have some work to do.  First we have to
+identify what will go in the PR.  On analysis we do need to move over the
+`bar` function, and the `baz` function, but we don't need the `foo` function.  So we edit `src/_skimage2/fakepkg/fake.py` to have only:
+
+```python
+def bar(d, f=10):
+    "Planned Skimage2 API changed"
+    return baz(a ** 2, f)
+
+def baz(g, h)
+    return g * 2 + h
+```
+
+Leaving `src/skimage/fakepkg/fake.py`:
+
+```python
+from _skimage2.fakepkg.fake import bar, baz
+
+@migration_warning('Default value of f changed in skimage2 from None to 10')
+def bar(d, f=None):
+    return bar(d, f)
+
+def foo(a, b, c):
+    "No Skimage2 changes yet proposed"
+    return bar(baz(a, b), c)
+```
+
+We also might want to split up the test function:
+
+`tests/_skimage2/fakepkg/tests/test_fake.py`:
+
+
+```python
+from _skimage2.fakepkg.fake import bar, baz
+
+def test_bar():
+    # Planned Skimage2 change of behavior.
+    assert bar(1)
+    assert bar(1, 2) == 3
+
+def test_baz():
+    # No planned Skimage2 change of behavior.
+    assert baz(1, 2) == 4
+```
+
+`tests/_skimage2/fakepkg/tests/test_fake.py`:
+
+
+```python
+from _skimage.fakepkg.fake import foo
+
+def test_foo():
+    # No planned Skimage2 change.
+    assert foo(1, 2, 3)
+```
+
+There are a few problems here.
+
+* We were tempted to first — analyze what code was using what, and then split
+  up files, increasing work.
+* We had to think about where our imports are coming from.
+* We are left, towards the end of the porting process, of pulling the bits of
+  the file still in `skimage` back into the code in `_skimage2`.
+* If we want to maintain the migration-log benefit of bit-by-bit, we have to
+  think about which functions are fully `_skimage2`-ready, and which are not.
+  For example, will we be changing `baz` or `foo` in Skimage2? This adds extra
+  complexity to the port process, and review.
+
+In contrast, it is more straightforward to do the port with the big-bang
+approach.  We already have copied tests
+(`tests/_skimage2/fakepkg/tests/test_fake.py`, so we just modify that
+appropriately, leaving the `skimage` version intact.  We don't have to split up the `fake.py` function, or think about which functions are fully Skimage2-ready, we concentrate on the changes of interest to us.   We do, of course, have to write suitable wrappers or alternative implementations in the `skimage` namespace, as before.
+
+### On the migration-log idea
+
+Given there are development costs for the bit-by-bit implementation, how great are the benefits, in particular, for the migration-log idea.
+
+The question has to be asked in relation to:
+
+* The problems we are expecting from incomplete migration.
+* Any alternatives we could use to track migration.
+* Our default position on change-by-default compared to stay-same-by-default.
+
+What problems are we predicting from migration?   There could be many, but
+I suspect the big ones will be where we have attempted to harmonize an API,
+but have missed a function — for example, for coordinate systems or
+in-function image scaling.
+
+Are these well-dealt with by making checks for these part of each PR process?
+Or are they better dealt with by screening the whole `_skimage2` codebase for
+instances, for example with AI, and dealing with those?   We will likely find
+it easier to whole-code-base screening and changes when all the code is in one
+`_skimage2` tree, rather than broken up into `_skimage2` and `skimage`.
+
+We do have alternative methods of tracking the ports.   For example, we could
+maintain a checklist like that in
+<https://github.com/scikit-image/scikit-image/wiki/API-changes-for-skimage2>.
+We could make it part of the PR process, maintaining that list.  I suppose one
+could argue that the partially filled `_skimage2` is a better log, but it is,
+at least, not as readable.
+
+Lastly — one could argue that, by forcing reviewers to think about whether all Skimage2 changes have been done, we can make sure we don't forget to make changes that occur to us as we port — but this begs the question of whether we should go looking for Skimage2 changes, or treat the default as "leave-as-is", on the basis that the greater the volume of changes, the higher the risk that Skimage1 users will not in fact migrate.
+
+Is the agreed (and debated, and updated) checklist page a better record of the changes we want to make?  One that might serve as a brake on lower-value changes?  And can we reassure ourselves we are ready for Skimage2 by careful review of the whole code-base (in `_skimage2`) when we are nearer release?
+
+(detailed-description)=
 
 ## Detailed description
 
-This section should provide a detailed description of the proposed
-change. It should include examples of how the new functionality would be
-used, intended use-cases, and pseudocode illustrating its use.
+This is just a sketch.   For now I'll put some LLM agent instructions, but we can think about how we would do this in practice.
+
+Draft LLM instructions:
+
+> The directory `src/_skimage2` contains code implementing the new version
+2 API of the scikit-image API.  The directory `src/skimage` contains the code
+implementing version 1 of the API.  There are matching tests in
+`tests/skimage2` and `tests/skimage` respectively.  Notice that, for code that
+has already reached `src/_skimage2`, there are matching wrappers in the `src/skimage` tree that imports the `_skimage2` code and implements the old version 1 API using the new version 2 code.
+>
+> Analyze these directory trees.   For every function or class that is not yet implemented in `_skimage2`, copy the implementation to `_skimage2` and import that function or class, now in `_skimage2`, back into the `skimage` namespace, with the same name and module path.   Copy all the tests not present in `tests/skimage` to matching positions in `tests/skimage2`.
+>
+> First run all the tests in `tests/skimage` to make sure you have correctly
+imported all functions from `_skimage2` to `skimage`, and fix accordingly.  Then run all the tests in `tests/skimage2` and fix accordingly.  Make sure that you can assert that a) no functions or classes are now missing from `_skimage2` what were in `skimage` and b) these functions and classes have all been correctly imported back into `skimage`, and c) that all tests for `skimage` are running and that d) all tests for `_skimage2` are running, and the tests for `_skimage2` are a superset of those for `skimage`.
 
 ## Related Work
 

--- a/doc/source/skips/5-v2-port-procedure.md
+++ b/doc/source/skips/5-v2-port-procedure.md
@@ -58,12 +58,12 @@ We could also call this approach "move-and-edit".
 #### Bit-by-bit
 
 This is our approach at time of writing. For each Skimage2-related change, we
-move the implementation of the relevant functions (etc) to the `src/_skmage2`
+move the implementation of the relevant functions (etc) to the `src/_skimage2`
 tree, along with the relevant tests, and make suitable wrappers that import and modify that implementation in the `src/skimage` tree.
 
 Thus the `_skimage2` namespace fills up gradually, as we do the migration of the API and other code.
 
-### Benefits and disbenefits from the approaches
+### Benefits and disadvantages of the two approaches
 
 First let's start with the general ideas, and then get down to specifics.
 

--- a/doc/source/skips/5-v2-port-procedure.md
+++ b/doc/source/skips/5-v2-port-procedure.md
@@ -38,7 +38,7 @@ There are two potential approaches to this problem.
 
 One implementation we will call "big-bang". Here we move all the current
 `skimage` implementations, that will have versions in Skimage2, into the
-`_skimage` namespace. We import the `_skimage2` implementations back into the
+`_skimage2` namespace. We import the `_skimage2` implementations back into the
 `skimage` namespace, while preserving the current `skimage` wrappers for
 already ported code.
 
@@ -47,7 +47,7 @@ We also copy all tests from `tests/skimage` to `tests/_skimage2`
 For more details in the procedure, see the [detailed description
 section](detailed-description) below.
 
-This leaves us with a complete `_skimage` namespace, but where we have yet to
+This leaves us with a complete `_skimage2` namespace, but where we have yet to
 complete the API and other changes in that namespace.
 
 After this, all Skimage2 changes take place in the `src/_skimage2` and

--- a/doc/source/skips/5-v2-port-procedure.md
+++ b/doc/source/skips/5-v2-port-procedure.md
@@ -263,14 +263,14 @@ instances, for example with AI, and dealing with those? We will likely find
 it easier to whole-code-base screening and changes when all the code is in one
 `_skimage2` tree, rather than broken up into `_skimage2` and `skimage`.
 
-#### Altnerative ways of tracking migration
+#### Alternative ways of tracking migration
 
 We should in any case, maintain a checklist like that in
 <https://github.com/scikit-image/scikit-image/wiki/API-changes-for-skimage2>.
 We could make it part of the PR process, maintaining that list.
 
 Note that, no matter what approach we take, any changed APIs in `_skimage2`
-*must* have wrappers or alternative implmentations in `skimage`.
+*must* have wrappers or alternative implementations in `skimage`.
 
 If we use the big-bang approach, these wrappers and implementations provide
 a full migration log, because any function that is, as yet, unmodified, will be
@@ -294,7 +294,7 @@ def somefunction(d, f=None):
 
 Lastly, I wonder whether the Certify requirement in the BBBC approach, will
 bias us to choose to make scikit-image v2 changes that we would not do (and
-should not do) without the Certify apporach. I suspect we'll find ourselves
+should not do) without the Certify approach. I suspect we'll find ourselves
 trying to think of any possible change we could make for scikit-image v2 in
 every PR, and I suspect that will lead to us making more changes, some of which
 will prove to 50-50 calls that probably aren't worth the disruption. This is

--- a/doc/source/skips/5-v2-port-procedure.md
+++ b/doc/source/skips/5-v2-port-procedure.md
@@ -26,9 +26,9 @@ We have already decided to have three namespaces:
 
 `skimage` can import directly from `_skimage2`, but `_skimage2` cannot import directly from `skimage`; if it does need `skimage` routines, it must do local (deferred, inline) imports, inside functions or methods, to avoid circular imports.
 
-We have also agreed that we should _copy_ tests from `skimage` (e.g. `tests/skimage/transform/tests` to `tests/skimage2/transform/tests` as we port.
+We have also agreed that we should _copy_ tests from `skimage` (e.g. `tests/skimage/transform/tests` to `tests/skimage2/transform/tests`) as we port.
 
-At some point, we will need a full Skimage2 implementation in `_skimage2`, with a full set of tests exercising that namespace. There will be a few functions and modules that will stay in `skimage`, such as everything in `skimage/future`, but otherwise, all or nearly all code in `skimage`
+At some point, we will need a full Skimage2 implementation in `_skimage2`, with a full set of tests exercising that namespace. There will be a few functions and modules that will stay in `skimage`, such as everything in `skimage/future`, but otherwise, all or nearly all code in `skimage` will move in some form to `_skimage2`.
 
 ### Big-bang or bit-by-bit
 
@@ -36,9 +36,9 @@ There are two potential approaches to this problem.
 
 #### Big-bang
 
-One implementation we will call "big-bang".  Here we move all the current
+One implementation we will call "big-bang". Here we move all the current
 `skimage` implementations, that will have versions in Skimage2, into the
-`_skimage` namespace.  We import the `_skimage2` implementations back into the
+`_skimage` namespace. We import the `_skimage2` implementations back into the
 `skimage` namespace, while preserving the current `skimage` wrappers for
 already ported code.
 
@@ -57,7 +57,7 @@ We could also call this approach "move-and-edit".
 
 #### Bit-by-bit
 
-This is our approach at time of writing.  For each Skimage2-related change, we
+This is our approach at time of writing. For each Skimage2-related change, we
 copy the implementation of the relevant functions (etc) to the `src/_skmage2`
 tree, along with the relevant tests, and make suitable wrappers that import and modify that implementation in the `src/skimage` tree.
 
@@ -74,24 +74,24 @@ a particular way, then we can reasonably believe that all the code /APIs in
 `src/_skimage2` is at least something like the code / APIs in the eventual
 first Skimage2 release.
 
-The "particular way" is one where we only ever move functions to `_skimage2` where we are confident that the code will continue to be about the same, and with the same API, as for Skimage2.  That is, in moving any code, we assert that this code is Skimage2 ready.
+The "particular way" is one where we only ever move functions to `_skimage2` where we are confident that the code will continue to be about the same, and with the same API, as for Skimage2. That is, in moving any code, we assert that this code is Skimage2 ready.
 
 The idea here is that we not only make partial Skimage2 changes, but we do all
-likely Skimage2 changes.  In that way, we can use the code in `_skimage2` (as
+likely Skimage2 changes. In that way, we can use the code in `_skimage2` (as
 compared to that in `skimage`) as a record of what changes we have done in the
-migration.  Call this the migration-log function of the bit-by-bit approach.
+migration. Call this the migration-log function of the bit-by-bit approach.
 
 #### Bit-by-bit as partial guarantee of future API
 
 With the big-bang approach, we can't initially tell users to start using
 `_skimage2` code, with the expectation that the code will, in fact, have the API of Skimage2 — because, at first, the code will be a still changing version of `skimage`.
 
-Of course, we could keep the `_skimage2` directory under wraps until it is mostly complete.   Or we could advertise only a few parts of the `_skimage2` / `skimage2` namespace.
+Of course, we could keep the `_skimage2` directory under wraps until it is mostly complete. Or we could advertise only a few parts of the `_skimage2` / `skimage2` namespace.
 
 #### Migration in practice
 
 Let's first consider the bit-by-bit approach, and some fake module `fake` in
-`src/skimage/fakepkg/fake.py`.   Let's assume the tests are in a single test
+`src/skimage/fakepkg/fake.py`. Let's assume the tests are in a single test
 module: `tests/skimage/fakepkg/tests/test_fake.py`.
 
 The `fake` module might look something like this:
@@ -131,9 +131,9 @@ def test_baz():
 Let us say we want to do a PR to change the default value of `bar` from None
 to 10.
 
-With the bit-by-bit approach, we have some work to do.  First we have to
-identify what will go in the PR.  On analysis we do need to move over the
-`bar` function, and the `baz` function, but we don't need the `foo` function.  So we edit `src/_skimage2/fakepkg/fake.py` to have only:
+With the bit-by-bit approach, we have some work to do. First we have to
+identify what will go in the PR. On analysis we do need to move over the
+`bar` function, and the `baz` function, but we don't need the `foo` function. So we edit `src/_skimage2/fakepkg/fake.py` to have only:
 
 ```python
 def bar(d, f=10):
@@ -162,7 +162,6 @@ We also might want to split up the test function:
 
 `tests/_skimage2/fakepkg/tests/test_fake.py`:
 
-
 ```python
 from _skimage2.fakepkg.fake import bar, baz
 
@@ -178,7 +177,6 @@ def test_baz():
 
 `tests/_skimage2/fakepkg/tests/test_fake.py`:
 
-
 ```python
 from _skimage.fakepkg.fake import foo
 
@@ -189,20 +187,20 @@ def test_foo():
 
 There are a few problems here.
 
-* We were tempted to first — analyze what code was using what, and then split
+- We were tempted to first — analyze what code was using what, and then split
   up files, increasing work.
-* We had to think about where our imports are coming from.
-* We are left, towards the end of the porting process, of pulling the bits of
+- We had to think about where our imports are coming from.
+- We are left, towards the end of the porting process, of pulling the bits of
   the file still in `skimage` back into the code in `_skimage2`.
-* If we want to maintain the migration-log benefit of bit-by-bit, we have to
+- If we want to maintain the migration-log benefit of bit-by-bit, we have to
   think about which functions are fully `_skimage2`-ready, and which are not.
   For example, will we be changing `baz` or `foo` in Skimage2? This adds extra
   complexity to the port process, and review.
 
 In contrast, it is more straightforward to do the port with the big-bang
-approach.  We already have copied tests
+approach. We already have copied tests
 (`tests/_skimage2/fakepkg/tests/test_fake.py`, so we just modify that
-appropriately, leaving the `skimage` version intact.  We don't have to split up the `fake.py` function, or think about which functions are fully Skimage2-ready, we concentrate on the changes of interest to us.   We do, of course, have to write suitable wrappers or alternative implementations in the `skimage` namespace, as before.
+appropriately, leaving the `skimage` version intact. We don't have to split up the `fake.py` function, or think about which functions are fully Skimage2-ready, we concentrate on the changes of interest to us. We do, of course, have to write suitable wrappers or alternative implementations in the `skimage` namespace, as before.
 
 ### On the migration-log idea
 
@@ -210,50 +208,50 @@ Given there are development costs for the bit-by-bit implementation, how great a
 
 The question has to be asked in relation to:
 
-* The problems we are expecting from incomplete migration.
-* Any alternatives we could use to track migration.
-* Our default position on change-by-default compared to stay-same-by-default.
+- The problems we are expecting from incomplete migration.
+- Any alternatives we could use to track migration.
+- Our default position on change-by-default compared to stay-same-by-default.
 
-What problems are we predicting from migration?   There could be many, but
+What problems are we predicting from migration? There could be many, but
 I suspect the big ones will be where we have attempted to harmonize an API,
 but have missed a function — for example, for coordinate systems or
 in-function image scaling.
 
 Are these well-dealt with by making checks for these part of each PR process?
 Or are they better dealt with by screening the whole `_skimage2` codebase for
-instances, for example with AI, and dealing with those?   We will likely find
+instances, for example with AI, and dealing with those? We will likely find
 it easier to whole-code-base screening and changes when all the code is in one
 `_skimage2` tree, rather than broken up into `_skimage2` and `skimage`.
 
-We do have alternative methods of tracking the ports.   For example, we could
+We do have alternative methods of tracking the ports. For example, we could
 maintain a checklist like that in
 <https://github.com/scikit-image/scikit-image/wiki/API-changes-for-skimage2>.
-We could make it part of the PR process, maintaining that list.  I suppose one
+We could make it part of the PR process, maintaining that list. I suppose one
 could argue that the partially filled `_skimage2` is a better log, but it is,
 at least, not as readable.
 
 Lastly — one could argue that, by forcing reviewers to think about whether all Skimage2 changes have been done, we can make sure we don't forget to make changes that occur to us as we port — but this begs the question of whether we should go looking for Skimage2 changes, or treat the default as "leave-as-is", on the basis that the greater the volume of changes, the higher the risk that Skimage1 users will not in fact migrate.
 
-Is the agreed (and debated, and updated) checklist page a better record of the changes we want to make?  One that might serve as a brake on lower-value changes?  And can we reassure ourselves we are ready for Skimage2 by careful review of the whole code-base (in `_skimage2`) when we are nearer release?
+Is the agreed (and debated, and updated) checklist page a better record of the changes we want to make? One that might serve as a brake on lower-value changes? And can we reassure ourselves we are ready for Skimage2 by careful review of the whole code-base (in `_skimage2`) when we are nearer release?
 
 (detailed-description)=
 
 ## Detailed description
 
-This is just a sketch.   For now I'll put some LLM agent instructions, but we can think about how we would do this in practice.
+This is just a sketch. For now I'll put some LLM agent instructions, but we can think about how we would do this in practice.
 
 Draft LLM instructions:
 
 > The directory `src/_skimage2` contains code implementing the new version
-2 API of the scikit-image API.  The directory `src/skimage` contains the code
-implementing version 1 of the API.  There are matching tests in
-`tests/skimage2` and `tests/skimage` respectively.  Notice that, for code that
-has already reached `src/_skimage2`, there are matching wrappers in the `src/skimage` tree that imports the `_skimage2` code and implements the old version 1 API using the new version 2 code.
+> 2 API of the scikit-image API. The directory `src/skimage` contains the code
+> implementing version 1 of the API. There are matching tests in
+> `tests/skimage2` and `tests/skimage` respectively. Notice that, for code that
+> has already reached `src/_skimage2`, there are matching wrappers in the `src/skimage` tree that imports the `_skimage2` code and implements the old version 1 API using the new version 2 code.
 >
-> Analyze these directory trees.   For every function or class that is not yet implemented in `_skimage2`, copy the implementation to `_skimage2` and import that function or class, now in `_skimage2`, back into the `skimage` namespace, with the same name and module path.   Copy all the tests not present in `tests/skimage` to matching positions in `tests/skimage2`.
+> Analyze these directory trees. For every function or class that is not yet implemented in `_skimage2`, copy the implementation to `_skimage2` and import that function or class, now in `_skimage2`, back into the `skimage` namespace, with the same name and module path. Copy all the tests not present in `tests/skimage` to matching positions in `tests/skimage2`.
 >
 > First run all the tests in `tests/skimage` to make sure you have correctly
-imported all functions from `_skimage2` to `skimage`, and fix accordingly.  Then run all the tests in `tests/skimage2` and fix accordingly.  Make sure that you can assert that a) no functions or classes are now missing from `_skimage2` what were in `skimage` and b) these functions and classes have all been correctly imported back into `skimage`, and c) that all tests for `skimage` are running and that d) all tests for `_skimage2` are running, and the tests for `_skimage2` are a superset of those for `skimage`.
+> imported all functions from `_skimage2` to `skimage`, and fix accordingly. Then run all the tests in `tests/skimage2` and fix accordingly. Make sure that you can assert that a) no functions or classes are now missing from `_skimage2` what were in `skimage` and b) these functions and classes have all been correctly imported back into `skimage`, and c) that all tests for `skimage` are running and that d) all tests for `_skimage2` are running, and the tests for `_skimage2` are a superset of those for `skimage`.
 
 ## Related Work
 

--- a/doc/source/skips/5-v2-port-procedure.md
+++ b/doc/source/skips/5-v2-port-procedure.md
@@ -242,7 +242,9 @@ namespace, as before.
 
 ### On the migration-log idea
 
-Gwiven there are development costs for the bit-by-bit implementation, how great are the benefits, in particular, for the migration-log idea.
+See also the section on [missing stuff to port](missing-portables).
+
+Given there are development costs for the bit-by-bit implementation, how great are the benefits, in particular, for the migration-log idea.
 
 The question has to be asked in relation to:
 
@@ -304,6 +306,46 @@ changes we want to make? One that might serve as a brake on lower-value
 changes? And can we reassure ourselves we are ready for scikit-image v2 by
 careful review of the whole code-base (in `_skimage2`) when we are nearer
 release?
+
+(missing-portables)=
+
+### Missing stuff to port
+
+This section is trying to unpack the worry that, without careful and frequent
+checks, we will miss necessary changes for `skimage2`.
+
+This does seem like it could be a problem, but what kind of problems can we predict?
+
+It seems to me there are two different sorts of porting problems.  These are
+*inconsistencies* and *missed opportunity*.
+
+1. We make some policy change, such as shifting to enforce `ij` ordering for
+   coordinates, but we miss this change in a `skimage2` function, making
+   `skimage2` *inconsistent* (missed change leading to inconsistency).
+2. With the benefit of hindsight, we might have preferred to make a change in
+   behavior for `skimage2`, but we forgot to make that change.  Call this
+   a *missed opportunity*.
+
+Bear in mind that we already have a list of proposed changes.  Assume (in the
+big-bang process) that it is part of a process of a PR that the author
+confirms that they have checked this list, and, if their PR relates to the
+listed changes, they have noted the progress / completion / remaining changes
+in this list.  Assume too that we specify that, before signing off on the
+`skimage2` namespace, we formally review and sign off on any remaining changes
+in this list.
+
+This means that any *missed opportunity* will be something that a) we thought
+of while we were doing the port (it's a new change) and b) have also forgotten to add to the list.   At least some, maybe most of these changes will be of relatively less importance that the big changes we've identified.   At worst, we have to wait for another longish deprecation cycle to make those changes, and at least, in the meantime, we've made our users' lives a bit easier by reducing the number of edits to their code to update.   Thus, it seems to me *missed opportunities* are a relatively minor concern.
+
+That brings us back to *inconsistencies*.  These are considerably more
+serious, and we should be careful to avoid them.  The question is, are per-PR
+checks for all relevant changes the correct way to avoid inconsistencies?
+Again, returning to the coordinate system changes — there are many such changes.  It would not be practical to enforce the rule that any PR must implement all possible related changes — for example — all changes to `ij` interpretation.   To do so would be to condemn us to very large PRs that are difficult to review.   If we do not have that rule, that reduces of the value of the per-PR checks for every possible `skimage2` change.   It seems to me that the more practical route is confirming that the changes in any give PR do implement some part of the route to the new API, and note the remaining parts (as discovered and elaborated during the PR) in the porting list.
+
+I (MB) would therefore argue that the more practical route to avoid
+inconsistent behavior is to do regular (perhaps per PR) review and updating of
+the porting list, rather than attempting to enforce full implementation in
+each PR.  And that, if we do enforce full review for any possible `skimage2` in each PR, that will have the effect of slowing us down, and making it more difficult to iterate through the changes.
 
 (detailed-description)=
 

--- a/doc/source/skips/index.md
+++ b/doc/source/skips/index.md
@@ -15,5 +15,6 @@ maxdepth: 1
 2-values
 3-transition-to-v1
 4-transition-to-v2
+5-v2-port-procedure
 template
 ```


### PR DESCRIPTION
This is the sketch of the proposal to start by moving all the code into
`_skimage2` and back-importing into `skimage`.
