### PR TITLE
ENH: improve error messages in registration module to include actual values

### DIFF
--- a/src/skimage/registration/_phase_cross_correlation.py
+++ b/src/skimage/registration/_phase_cross_correlation.py
@@ -324,8 +324,8 @@ def phase_cross_correlation(
 
     # images must be the same shape
     if reference_image.shape != moving_image.shape:
-        raise ValueError(
-            f"reference_image and moving_image must have the same shape, "
+            "reference_image and moving_image must have the same shape, "
+            f"but got {reference_image.shape} and {moving_image.shape}."
             f"but got {reference_image.shape} and {moving_image.shape}."
         )
 

--- a/src/skimage/registration/_phase_cross_correlation.py
+++ b/src/skimage/registration/_phase_cross_correlation.py
@@ -324,7 +324,10 @@ def phase_cross_correlation(
 
     # images must be the same shape
     if reference_image.shape != moving_image.shape:
-        raise ValueError("images must be same shape")
+        raise ValueError(
+            f"reference_image and moving_image must have the same shape, "
+            f"but got {reference_image.shape} and {moving_image.shape}."
+        )
 
     # assume complex data is already in Fourier space
     if space.lower() == 'fourier':


### PR DESCRIPTION
## Summary

Improve ValueError messages in the registration module to include the
actual values that caused the error, making debugging easier for users.

### Changes
- `_phase_cross_correlation.py`: include both image shapes in the shape
  mismatch error

### Before
ValueError: images must be same shape

### After 
ValueError: reference_image and moving_image must have the same shape,
but got (10, 10) and (10, 12).

No existing behavior is changed — only the error message text.