### PR TITLE
Restore wording of AI policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,17 @@
-## Description
-
 <!--
-- Reference relevant issues or related pull requests with their URL / #<number>.
-- Use `pre-commit` to check and format code.
+Please see the Contribution Guide:
+https://scikit-image.org/docs/dev/development/contribute.html
+For newcomers: this document has a checklist of what we expect in a PR.
+
+Also please note our AI policy:
+https://scikit-image.org/docs/dev/development/contribute.html#ai-policy
 -->
 
-## Checklist
+<!-- ... PR description goes here ... -->
 
-<!-- Before pull requests can be merged, they should provide: -->
+### Release note (optional)
 
-- A descriptive but concise pull request title
-- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
-- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
-- A gallery example in `./doc/examples` for new features
-- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed
-
-## Release note
-
-For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.
+<!-- See https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes -->
 
 ```release-note
 ...

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -25,17 +25,6 @@ shy, the team is very friendly!
 .. contents::
    :local:
 
-
-PR Checklist
-------------
-
-- Concise, descriptive title
-- `Docstrings for all functions <https://github.com/numpy/numpydoc/blob/main/doc/example.py>`_
-- `Unit tests <https://scikit-image.org/docs/dev/development/contribute.html#testing>`_
-- For new features, a gallery example in `./doc/examples`
-- Tools disclosure: in case tools other than a text editor were used
-  in creating the PR
-
 AI Policy
 ---------
 Regardless of how a PR was produced, scikit-image requires that
@@ -116,21 +105,27 @@ can be contributed to scikit-image.
      Please write `good commit messages
      <https://vxlabs.com/software-development-handbook/#good-commit-messages>`_.
 
+   * It is a good idea to read our :ref:`Guidelines` at this point.
+     While we don't require a contribution to meet every guideline from the
+     start, they will come up during review.
+
 3. To submit your contribution:
 
-   * Push your changes back to your fork on GitHub:
-
-     ::
+   * Push your changes back to your fork on GitHub::
 
        git push codemonkey transform-speedups
 
      A message will be displayed with a URL to open in your browser to create a
-     pull request (PR). Open it and click the green button.
+     pull request (PR).
 
-.. tip::
+   * Before submitting the pull request:
 
-   If you get stuck, reach out to us on
-   `our Zulip chat <https://skimage.zulipchat.com/>`__.
+     - Use a concise, descriptive title
+     - Describe and link relevant context in the description
+     - Disclose all _generative_ tools (AI, LLMs) that you used
+
+   .. tip:: If you get stuck, reach out to us on
+      `our Zulip chat <https://skimage.zulipchat.com/>`__.
 
 4. Review process:
 
@@ -211,6 +206,8 @@ to make conflict markers easier to read.
 
 An alternative to merging is to rebase your branch—but we squash and merge all
 PRs anyway, so we don't mind merge commits.
+
+.. _guidelines:
 
 Guidelines
 ----------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -30,22 +30,31 @@ PR Checklist
 ------------
 
 - Concise, descriptive title
-- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
-- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
+- `Docstrings for all functions <https://github.com/numpy/numpydoc/blob/main/doc/example.py>`_
+- `Unit tests <https://scikit-image.org/docs/dev/development/contribute.html#testing>`_
 - For new features, a gallery example in `./doc/examples`
-- Tools declaration: in case tools other than a text editor were used
+- Tools disclosure: in case tools other than a text editor were used
   in creating the PR
 
 AI Policy
 ---------
-We are a small developer team, and we enjoy reviewing and discussing code written by other humans.
-If, despite our strong preference, you decide to use AI to make a PR, please:
+Regardless of how a PR was produced, scikit-image requires that
+authors illustrate a thorough understanding of any proposed changes.
+You **must review such code line-by-line**—it is **your
+responsibility** to ensure that it is correct, and that it does not
+breach copyright. You should expect the team to ask questions about
+your work.
 
-1. indicate *how* you used it in the PR description;
-2. make sure you *fully understand* all the changes so we can ask you
-   about them; and
-3. be prepared to argue that the code does not breach any copyright or license terms
-   (yes, we take those seriously!).
+scikit-image is technically complex, key infrastructure; therefore, we
+place a high premium on correctness, and on avoiding technical
+complexity that may affect maintainability. If you want to make use of
+LLMs in a significant way, we ask that you **please check in with us
+first**. Regardless, **always declare tool usage**.
+
+AI agents that have followed all guidelines in this document (outside
+of this section) may add 🤖 to their PR title. This signals to
+maintainers that the agent has self-verified compliance, enabling
+expedited review and acceptance.
 
 Development process
 -------------------
@@ -238,7 +247,7 @@ Stylistic Guidelines
 * Use numpy data types instead of strings (``np.uint8`` instead of
   ``"uint8"``).
 
-* When documenting array parameters, use ``image : ndarray of shape (M, N)``
+* When documenting array parameters, use ``image : (M, N) ndarray``
   and then refer to ``M`` and ``N`` in the docstring, if necessary.
 
 * Refer to array dimensions as (plane), row, column, not as x, y, z. See
@@ -271,37 +280,24 @@ Testing
 The test suite must pass before a pull request can be merged, and
 tests should be added to cover all modifications in behavior.
 
-Tests are located in the ``tests/`` directory.
-We also test examples in docstrings of our package (located in ``src/``).
+We use the `pytest <https://docs.pytest.org/en/latest/>`__ testing
+framework, with tests located in the various
+``skimage/submodule/tests`` folders.
 
-For local development we use ``spin test`` which wraps the
-`pytest testing framework <https://docs.pytest.org/en/latest/>`__.
-Examples of running ``spin test``:
+Testing requirements are listed in `requirements/test.txt`.
+Run:
 
-.. code-block:: shell
-
-    # All tests
-    spin test
-
-    # Tests inside directory(s)
-    spin test -- tests/skimage/morphology
-    spin test -- src/skimage/morphology tests/skimage/morphology
-
-    # Tests matching an expression
-    spin test -- -k threshold
-
-    # Combine above with test path to reduce test collection time
-    spin test -- tests/skimage/filters -k threshold
-
-    # Specific test
-    spin test -- tests/skimage/morphology/test_gray.py::test_3d_fallback_black_tophat
-
-.. tip::
-
-    Arguments specified after the ``--`` are forwarded as
-    `options to pytest <https://docs.pytest.org/en/stable/reference/reference.html#command-line-flags>`__.
-
-Testing requirements are listed in ``requirements/test.txt``.
+- **All tests**: ``spin test``
+- Tests for a **submodule**: ``spin test src/skimage/morphology``
+- Run tests from a **specific file**: ``spin test tests/skimage/morphology/tests/test_gray.py``
+- Run **a test inside a file**:
+  ``spin test tests/skimage/morphology/tests/test_gray.py::test_3d_fallback_black_tophat``
+- Run tests with **arbitrary ``pytest`` options**:
+  ``spin test -- any pytest args you want``.
+- Run tests **matching** a specific expression:
+  ``spin test -- -k threshold``
+- Run all tests and **doctests**:
+  ``spin test --with-doctest``
 
 
 Warnings during testing phase
@@ -524,12 +520,12 @@ to perform the above procedure.
 
 Adding Data
 -----------
-While code is hosted on `GitHub <https://github.com/scikit-image/>`_,
-example datasets are on `GitLab <https://gitlab.com/scikit-image/data>`_.
+While code is hosted on `github <https://github.com/scikit-image/>`_,
+example datasets are on `gitlab <https://gitlab.com/scikit-image/data>`_.
 These are fetched with `pooch <https://github.com/fatiando/pooch>`_
-when accessing ``skimage.data.*``.
+when accessing `skimage.data.*`.
 
-New datasets are submitted on GitLab and, once merged, the data
+New datasets are submitted on gitlab and, once merged, the data
 registry ``skimage/data/_registry.py`` in the main GitHub repository
 can be updated.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -25,26 +25,6 @@ shy, the team is very friendly!
 .. contents::
    :local:
 
-AI Policy
----------
-Regardless of how a PR was produced, scikit-image requires that
-authors illustrate a thorough understanding of any proposed changes.
-You **must review such code line-by-line**—it is **your
-responsibility** to ensure that it is correct, and that it does not
-breach copyright. You should expect the team to ask questions about
-your work.
-
-scikit-image is technically complex, key infrastructure; therefore, we
-place a high premium on correctness, and on avoiding technical
-complexity that may affect maintainability. If you want to make use of
-LLMs in a significant way, it is a very good idea to **check in with us
-first**. Regardless, **always declare tool usage**.
-
-AI agents that have followed all guidelines in this document (outside
-of this section) may add 🤖 to their PR title. This signals to
-maintainers that the agent has self-verified compliance, enabling
-expedited review and acceptance.
-
 Development process
 -------------------
 The following is a brief overview about how changes to source code and documentation
@@ -105,7 +85,7 @@ can be contributed to scikit-image.
      Please write `good commit messages
      <https://vxlabs.com/software-development-handbook/#good-commit-messages>`_.
 
-   * It is a good idea to read our :ref:`Guidelines` at this point.
+   * It is a good idea to read our :ref:`guidelines` at this point.
      While we don't require a contribution to meet every guideline from the
      start, they will come up during review.
 
@@ -122,7 +102,8 @@ can be contributed to scikit-image.
 
      - Use a concise, descriptive title
      - Describe and link relevant context in the description
-     - Disclose all _generative_ tools (AI, LLMs) that you used
+     - Disclose all _generative_ tools (AI, LLMs, agents) that you used, see our
+       :ref:`ai-policy` for details.
 
    .. tip:: If you get stuck, reach out to us on
       `our Zulip chat <https://skimage.zulipchat.com/>`__.
@@ -206,6 +187,28 @@ to make conflict markers easier to read.
 
 An alternative to merging is to rebase your branch—but we squash and merge all
 PRs anyway, so we don't mind merge commits.
+
+.. _ai-policy:
+
+AI Policy
+---------
+Regardless of how a PR was produced, scikit-image requires that
+authors illustrate a thorough understanding of any proposed changes.
+You **must review such code line-by-line**—it is **your
+responsibility** to ensure that it is correct, and that it does not
+breach copyright. You should expect the team to ask questions about
+your work.
+
+scikit-image is technically complex, key infrastructure; therefore, we
+place a high premium on correctness, and on avoiding technical
+complexity that may affect maintainability. If you want to make use of
+LLMs in a significant way, it is a very good idea to **check in with us
+first**. Regardless, **always declare tool usage**.
+
+AI agents that have followed all guidelines in this document (outside
+of this section) may add 🤖 to their PR title. This signals to
+maintainers that the agent has self-verified compliance, enabling
+expedited review and acceptance.
 
 .. _guidelines:
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -520,12 +520,12 @@ to perform the above procedure.
 
 Adding Data
 -----------
-While code is hosted on `github <https://github.com/scikit-image/>`_,
-example datasets are on `gitlab <https://gitlab.com/scikit-image/data>`_.
+While code is hosted on `GitHub <https://github.com/scikit-image/>`_,
+example datasets are on `GitLab <https://gitlab.com/scikit-image/data>`_.
 These are fetched with `pooch <https://github.com/fatiando/pooch>`_
-when accessing `skimage.data.*`.
+when accessing ``skimage.data.*``.
 
-New datasets are submitted on gitlab and, once merged, the data
+New datasets are submitted on GitLab and, once merged, the data
 registry ``skimage/data/_registry.py`` in the main GitHub repository
 can be updated.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -102,7 +102,7 @@ can be contributed to scikit-image.
 
      - Use a concise, descriptive title
      - Describe and link relevant context in the description
-     - Disclose all _generative_ tools (AI, LLMs, agents) that you used, see our
+     - Disclose all *generative* tools (AI, LLMs, agents) that you used, see our
        :ref:`ai-policy` for details.
 
    .. tip:: If you get stuck, reach out to us on

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -48,7 +48,7 @@ your work.
 scikit-image is technically complex, key infrastructure; therefore, we
 place a high premium on correctness, and on avoiding technical
 complexity that may affect maintainability. If you want to make use of
-LLMs in a significant way, we ask that you **please check in with us
+LLMs in a significant way, it is a very good idea to **check in with us
 first**. Regardless, **always declare tool usage**.
 
 AI agents that have followed all guidelines in this document (outside
@@ -247,7 +247,7 @@ Stylistic Guidelines
 * Use numpy data types instead of strings (``np.uint8`` instead of
   ``"uint8"``).
 
-* When documenting array parameters, use ``image : (M, N) ndarray``
+* When documenting array parameters, use ``image : ndarray of shape (M, N)``
   and then refer to ``M`` and ``N`` in the docstring, if necessary.
 
 * Refer to array dimensions as (plane), row, column, not as x, y, z. See
@@ -280,24 +280,37 @@ Testing
 The test suite must pass before a pull request can be merged, and
 tests should be added to cover all modifications in behavior.
 
-We use the `pytest <https://docs.pytest.org/en/latest/>`__ testing
-framework, with tests located in the various
-``skimage/submodule/tests`` folders.
+Tests are located in the ``tests/`` directory.
+We also test examples in docstrings of our package (located in ``src/``).
+
+For local development we use ``spin test`` which wraps the
+`pytest testing framework <https://docs.pytest.org/en/latest/>`__.
+Examples of running ``spin test``:
+
+.. code-block:: shell
+
+    # All tests
+    spin test
+
+    # Tests inside directory(s)
+    spin test -- tests/skimage/morphology
+    spin test -- src/skimage/morphology tests/skimage/morphology
+
+    # Tests matching an expression
+    spin test -- -k threshold
+
+    # Combine above with test path to reduce test collection time
+    spin test -- tests/skimage/filters -k threshold
+
+    # Specific test
+    spin test -- tests/skimage/morphology/test_gray.py::test_3d_fallback_black_tophat
+
+.. tip::
+
+    Arguments specified after the ``--`` are forwarded as
+    `options to pytest <https://docs.pytest.org/en/stable/reference/reference.html#command-line-flags>`__.
 
 Testing requirements are listed in ``requirements/test.txt``.
-Run:
-
-- **All tests**: ``spin test``
-- Tests for a **submodule**: ``spin test src/skimage/morphology``
-- Run tests from a **specific file**: ``spin test tests/skimage/morphology/tests/test_gray.py``
-- Run **a test inside a file**:
-  ``spin test tests/skimage/morphology/tests/test_gray.py::test_3d_fallback_black_tophat``
-- Run tests with **arbitrary ``pytest`` options**:
-  ``spin test -- any pytest args you want``.
-- Run tests **matching** a specific expression:
-  ``spin test -- -k threshold``
-- Run all tests and **doctests**:
-  ``spin test --with-doctest``
 
 
 Warnings during testing phase

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -202,7 +202,7 @@ your work.
 scikit-image is technically complex, key infrastructure; therefore, we
 place a high premium on correctness, and on avoiding technical
 complexity that may affect maintainability. If you want to make use of
-LLMs in a significant way, it is a very good idea to **check in with us
+LLMs in a significant way, it is a good idea to **check in with us
 first**. Regardless, **always declare tool usage**.
 
 AI agents that have followed all guidelines in this document (outside

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -284,7 +284,7 @@ We use the `pytest <https://docs.pytest.org/en/latest/>`__ testing
 framework, with tests located in the various
 ``skimage/submodule/tests`` folders.
 
-Testing requirements are listed in `requirements/test.txt`.
+Testing requirements are listed in ``requirements/test.txt``.
 Run:
 
 - **All tests**: ``spin test``


### PR DESCRIPTION
This is the intended wording of https://github.com/scikit-image/scikit-image/pull/7982, restored.