### PR TITLE
Revert "Add AI contribution policy (#7982)"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,23 @@
-<!--
-Please see the Contribution Guide:
-https://scikit-image.org/docs/dev/development/contribute.html
-For newcomers: this document has a checklist of what we expect in a PR.
+## Description
 
-Also please note our AI policy:
-https://scikit-image.org/docs/dev/development/contribute.html#ai-policy
+<!--
+- Reference relevant issues or related pull requests with their URL / #<number>.
+- Use `pre-commit` to check and format code.
 -->
 
-<!-- ... PR description goes here ... -->
+## Checklist
 
-### Release note (optional)
+<!-- Before pull requests can be merged, they should provide: -->
 
-<!-- See https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes -->
+- A descriptive but concise pull request title
+- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
+- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
+- A gallery example in `./doc/examples` for new features
+- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed
+
+## Release note
+
+For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.
 
 ```release-note
 ...

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -25,28 +25,6 @@ shy, the team is very friendly!
 .. contents::
    :local:
 
-
-PR Checklist
-------------
-
-- Concise, descriptive title
-- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
-- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
-- For new features, a gallery example in `./doc/examples`
-- Tools declaration: in case tools other than a text editor were used
-  in creating the PR
-
-AI Policy
----------
-We are a small developer team, and we enjoy reviewing and discussing code written by other humans.
-If, despite our strong preference, you decide to use AI to make a PR, please:
-
-1. indicate *how* you used it in the PR description;
-2. make sure you *fully understand* all the changes so we can ask you
-   about them; and
-3. be prepared to argue that the code does not breach any copyright or license terms
-   (yes, we take those seriously!).
-
 Development process
 -------------------
 The following is a brief overview about how changes to source code and documentation


### PR DESCRIPTION
On request from @stefanv, this reverts commit 5cda688f2911ed19caf811645888a0c7fdc882d9 while we iterate on https://github.com/scikit-image/scikit-image/pull/8123.

<!--
Please see the Contribution Guide:
https://scikit-image.org/docs/dev/development/contribute.html
For newcomers: this document has a checklist of what we expect in a PR.

Also please note our AI policy:
https://scikit-image.org/docs/dev/development/contribute.html#ai-policy
-->

<!-- ... PR description goes here ... -->

### Release note (optional)

<!-- See https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes -->

```release-note
...
```
