### PR TITLE
Drop 3.13t builds from cibuildwheel configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -265,7 +265,6 @@ test-sources = ["tests", "pyproject.toml"]
 environment = {PIP_PREFER_BINARY=1}
 environment-pass = ["SKIMAGE_LINK_FLAGS", "PIP_EXTRA_INDEX_URL", "COLUMNS"]
 build-verbosity = 0
-enable="cpython-freethreading"
 
 [tool.cibuildwheel.config-settings]
 # Could be overwritten using CIBW_CONFIG_SETTINGS environment variable


### PR DESCRIPTION
See the note at https://cibuildwheel.pypa.io/en/stable/changelog/#v341 and https://github.com/pypa/cibuildwheel/pull/2787.

This option will be removed in the next release of cibuildwheel.

I'm going through repositories on GitHub that enable this option and sending in PRs to disable it. Happy to answer questions about this.

If you're curious why 3.13t support is going away so soon, see https://py-free-threading.github.io/ci/#building-free-threaded-wheels-with-cibuildwheel for further guidance.