### PR TITLE
Complete docstrings for hsv_value and each_channel

### DIFF
--- a/src/skimage/color/adapt_rgb.py
+++ b/src/skimage/color/adapt_rgb.py
@@ -85,7 +85,7 @@ def each_channel(image_filter, image, *args, **kwargs):
     image_filter : function
         Function that filters a gray-scale image.
     image : array_like of shape (M, N, C)
-        Input RGB(A) image with `C` channels along the last axis.
+        Input image with `C` channels along the last axis.
     *args : tuple
         Additional positional arguments passed to `image_filter`.
     **kwargs : dict

--- a/src/skimage/color/adapt_rgb.py
+++ b/src/skimage/color/adapt_rgb.py
@@ -54,8 +54,18 @@ def hsv_value(image_filter, image, *args, **kwargs):
     ----------
     image_filter : function
         Function that filters a gray-scale image.
-    image : array
-        Input image. Note that RGBA images are treated as RGB.
+    image : array_like of shape (M, N, 3) or (M, N, 4)
+        Input RGB(A) image. Alpha channels are stripped before filtering.
+    *args : tuple
+        Additional positional arguments passed to `image_filter`.
+    **kwargs : dict
+        Additional keyword arguments passed to `image_filter`.
+
+    Returns
+    -------
+    out : ndarray of shape (M, N, 3)
+        RGB image obtained by applying `image_filter` to the value channel
+        of `image` in HSV space.
     """
     # Slice the first three channels so that we remove any alpha channels.
     hsv = color.rgb2hsv(image[:, :, :3])
@@ -74,8 +84,17 @@ def each_channel(image_filter, image, *args, **kwargs):
     ----------
     image_filter : function
         Function that filters a gray-scale image.
-    image : array
-        Input image.
+    image : array_like of shape (M, N, C)
+        Input RGB(A) image with `C` channels along the last axis.
+    *args : tuple
+        Additional positional arguments passed to `image_filter`.
+    **kwargs : dict
+        Additional keyword arguments passed to `image_filter`.
+
+    Returns
+    -------
+    out : ndarray of shape (M, N, C)
+        Color image obtained by stacking the filtered channels.
     """
     c_new = [image_filter(c, *args, **kwargs) for c in np.moveaxis(image, -1, 0)]
     return np.stack(c_new, axis=-1)


### PR DESCRIPTION
Closes #7270.                                                                                        
                                               
  The docstrings of `adapt_rgb.hsv_value` and `adapt_rgb.each_channel` were missing documentation for    
  `*args`, `**kwargs`, and the return value, and didn't make clear that `image` is expected to be an
  RGB(A) array. Both helpers share the same defect; this PR fixes all four points for both functions.    
                                                                                                       
  The follow-up note from @lagru in the issue — exposing `hsv_value`/`each_channel` via the              
  `skimage.color` public API — is intentionally left for a separate PR.
                                                                                                         
  ### Verification                                                                                     
  - `pre-commit run --files src/skimage/color/adapt_rgb.py` passes (ruff, ruff-format, and all other
  hooks).                                                                                                
  - Indent style and `array_like of shape (...)` / `ndarray of shape (...)` annotations match the
  conventions used in the neighboring `colorconv.py`.                                                    
                                                                                                       
  ### AI tool disclosure                                                                                 
  Per the project's AI policy: this PR was prepared with the assistance of Claude (an AI coding        
  assistant). I reviewed each line of the change and confirm it accurately reflects the behavior of the  
  functions in `adapt_rgb.py`.