### PR TITLE
Suppress tifffile DeprecationWarning in test_plugin_deprecation_on_imread

### DIFF
--- a/tests/skimage/io/test_io.py
+++ b/tests/skimage/io/test_io.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 import tempfile
+import warnings
 
 import numpy as np
 import pytest
@@ -130,13 +131,16 @@ def test_failed_temporary_file(monkeypatch, error_class):
 def test_plugin_deprecation_on_imread(kwarg):
     path = fetch("data/multipage.tif")
     regex = ".*use `imageio` or other I/O packages directly.*"
-    with pytest.warns(FutureWarning, match=regex) as record:
-        # tifffile raises "DeprecationWarning: Setting the shape on a NumPy array
-        # has been deprecated in NumPy 2.5" — suppress until fixed upstream.
-        # TODO: remove once tifffile > 2026.4.11 is released.
-        with pytest.warns(
-            DeprecationWarning, match="Setting the shape on a NumPy array"
-        ):
+    # tifffile raises "DeprecationWarning: Setting the shape on a NumPy array
+    # has been deprecated in NumPy 2.5" on NumPy >= 2.5 — suppress until fixed
+    # upstream. TODO: remove once tifffile > 2026.4.11 is released.
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="Setting the shape on a NumPy array",
+            category=DeprecationWarning,
+        )
+        with pytest.warns(FutureWarning, match=regex) as record:
             io.imread(path, **kwarg)
     assert len(record) == 1
     assert_stacklevel(record, offset=-2)

--- a/tests/skimage/io/test_io.py
+++ b/tests/skimage/io/test_io.py
@@ -131,7 +131,13 @@ def test_plugin_deprecation_on_imread(kwarg):
     path = fetch("data/multipage.tif")
     regex = ".*use `imageio` or other I/O packages directly.*"
     with pytest.warns(FutureWarning, match=regex) as record:
-        io.imread(path, **kwarg)
+        # tifffile raises "DeprecationWarning: Setting the shape on a NumPy array
+        # has been deprecated in NumPy 2.5" — suppress until fixed upstream.
+        # TODO: remove once tifffile > 2026.4.11 is released.
+        with pytest.warns(
+            DeprecationWarning, match="Setting the shape on a NumPy array"
+        ):
+            io.imread(path, **kwarg)
     assert len(record) == 1
     assert_stacklevel(record, offset=-2)
 

--- a/tests/skimage/io/test_io.py
+++ b/tests/skimage/io/test_io.py
@@ -134,13 +134,16 @@ def test_plugin_deprecation_on_imread(kwarg):
     # tifffile raises "DeprecationWarning: Setting the shape on a NumPy array
     # has been deprecated in NumPy 2.5" on NumPy >= 2.5 — suppress until fixed
     # upstream. TODO: remove once tifffile > 2026.4.11 is released.
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message="Setting the shape on a NumPy array",
-            category=DeprecationWarning,
-        )
-        with pytest.warns(FutureWarning, match=regex) as record:
+    with pytest.warns(FutureWarning, match=regex) as record:
+        # tifffile raises "DeprecationWarning: Setting the shape on a NumPy array
+        # has been deprecated in NumPy 2.5" — suppress until fixed upstream.
+        # TODO: remove once tifffile > 2026.4.11 is released.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="Setting the shape on a NumPy array",
+                category=DeprecationWarning,
+            )
             io.imread(path, **kwarg)
     assert len(record) == 1
     assert_stacklevel(record, offset=-2)


### PR DESCRIPTION
Fixes #8135

`tifffile` raises `DeprecationWarning: Setting the shape on a NumPy array has been deprecated in NumPy 2.5` during `io.imread` calls on TIFF files. This causes `test_plugin_deprecation_on_imread` to fail because the test's `pytest.warns(FutureWarning)` context sees an unexpected warning.

This PR wraps the `io.imread` call in an additional `pytest.warns(DeprecationWarning)` context to suppress it until tifffile > 2026.4.11 is released with a fix.
