### PR TITLE
Libraries other than tifffile also set NumPy array shapes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,8 +227,8 @@ filterwarnings = [
     "ignore:.*JsProxy\\.as_object_map.*:RuntimeWarning",
     # Warning caused by matplotlib 3.7.0 because it uses deprecated API of pyparsing 3.3.1
     "ignore:.*(parseString|resetCache|enablePackrat|oneOf).*:DeprecationWarning:matplotlib",
-    # tifffile (v2025.12.20) uses deprecated NumPy API
-    "ignore:Setting the shape on a NumPy array:DeprecationWarning:tifffile",
+    # tifffile, imageio, and others use deprecated NumPy 2.5 API
+    "ignore:Setting the shape on a NumPy array:DeprecationWarning",
     # pytest warning when running under PYTHONOPTIMIZE=2 (assertions are stripped)
     "ignore:assertions not in test modules or plugins:pytest.PytestConfigWarning",
 ]


### PR DESCRIPTION
We can ignore; we've fixed all internal occurrences.