### PR TITLE
Update pyodide CI test to match the pattern used by numpy

### DIFF
--- a/.github/workflows/test-pyodide.yaml
+++ b/.github/workflows/test-pyodide.yaml
@@ -2,20 +2,7 @@
 
 name: Test Pyodide
 
-on:
-  push:
-    branches:
-      - main
-      - maintenance/**
-  pull_request:
-    branches:
-      - main
-      - maintenance/**
-    paths-ignore:
-      - "**.pyi"
-      - "**.md"
-      - "**.rst"
-  merge_group:
+on: [push, pull_request, merge_group]
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/test-pyodide.yaml
+++ b/.github/workflows/test-pyodide.yaml
@@ -3,6 +3,10 @@
 name: Test Pyodide
 
 on:
+  push:
+    branches:
+      - main
+      - maintenance/**
   pull_request:
     branches:
       - main
@@ -11,6 +15,7 @@ on:
       - "**.pyi"
       - "**.md"
       - "**.rst"
+  merge_group:
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/test-pyodide.yaml
+++ b/.github/workflows/test-pyodide.yaml
@@ -1,90 +1,40 @@
-# Copied from NumPy https://github.com/numpy/numpy/pull/25894
-# https://github.com/numpy/numpy/blob/d2d2c25fa81b47810f5cbd85ea6485eb3a3ffec3/.github/workflows/emscripten.yml
-#
+# Copied from NumPy https://github.com/numpy/numpy/blob/d4e5fafa28f4198c535e64ec18584f9ffd180d4d/.github/workflows/emscripten.yml
 
 name: Test Pyodide
 
-on: [push, pull_request, merge_group]
+on:
+  pull_request:
+    branches:
+      - main
+      - maintenance/**
+    paths-ignore:
+      - "**.pyi"
+      - "**.md"
+      - "**.rst"
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
 
 env:
   FORCE_COLOR: 3
-  PYTEST: "pytest --config-file ${{ github.workspace }}/pyproject.toml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-permissions:
-  contents: read # to fetch code (actions/checkout)
-
 jobs:
   build-wasm-emscripten:
-    name: "pyodide${{ matrix.PYODIDE_VERSION }}\
-      -cp${{ matrix.PYTHON_VERSION }}\
-      -emscr${{ matrix.EMSCRIPTEN_VERSION }}"
-    runs-on: ubuntu-24.04
-    strategy:
-      # Ensure that wheel builder finishes even if another one fails
-      fail-fast: false
-      matrix:
-        # Use `includes:` if you want to specify other combinations!
-        # PYTHON_VERSION and EMSCRIPTEN_VERSION are determined by PYODIDE_VERSION.
-        # The appropriate version combinations can be found in the Pyodide repodata.json
-        # "info" field, or in Makefile.envs:
-        # https://github.com/pyodide/pyodide/blob/main/Makefile.envs#L2
-        PYODIDE_VERSION: ["0.29.3"]
-        PYTHON_VERSION: ["3.13"]
-        EMSCRIPTEN_VERSION: ["4.0.9"]
-        NODE_VERSION: ["24"]
-        PYODIDE_BUILD_VERSION: ["0.33.0"]
-
+    name: Pyodide test
+    runs-on: ubuntu-22.04
+    # To enable this workflow on a fork, comment out:
+    if: github.repository == 'scikit-image/scikit-image'
     steps:
       - name: Checkout scikit-image
-        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - name: Set up Python ${{ matrix.PYTHON_VERSION }}
-        id: setup-python
-        uses: actions/setup-python@2e3e4b15a884dc73a63f962bff250a855150a234 # v5.0.0
-        with:
-          python-version: ${{ matrix.PYTHON_VERSION }}
-          cache: "pip"
-          cache-dependency-path: "requirements/*.txt"
-
-      - name: Set up Emscripten toolchain
-        uses: mymindstorm/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14
-        with:
-          version: ${{ matrix.EMSCRIPTEN_VERSION }}
-          actions-cache-folder: emsdk-cache
-
-      - name: Install pyodide-build
-        run: pip install pyodide-build==${{ matrix.PYODIDE_BUILD_VERSION }}
-
-      - name: Build scikit-image for Pyodide
-        run: |
-          pyodide xbuildenv install ${{ matrix.PYODIDE_VERSION }}
-          pyodide build
-
-      - name: Set up Node.js
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
-        with:
-          node-version: ${{ matrix.NODE_VERSION }}
-
-      - name: Set up Pyodide test environment
-        run: |
-          # Set up Pyodide virtual environment
-          pyodide venv .venv-pyodide
-
-          # Activate the virtual environment and install the built scikit-image wheel
-          source .venv-pyodide/bin/activate
-          pip install dist/*.whl
-
-          # Install pytest and optional dependencies that are available
-          pip install pytest pytest-pretty
-          pip install "astropy" "dask[array]" "matplotlib" "PyWavelets" "scikit-learn"
-
-      - name: Test scikit-image
-        run: |
-          source .venv-pyodide/bin/activate
-          $PYTEST -svra --pyargs skimage ./tests
+      - uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
+        env:
+          CIBW_PLATFORM: pyodide
+          CIBW_BUILD: cp313-pyodide_wasm32

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -302,5 +302,5 @@ before-all = [
 ]
 
 [tool.cibuildwheel.pyodide]
-test-command = "pytest --pyargs skimage tests"
+test-command = "pytest ./tests"
 test-extras = ["test"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -303,3 +303,4 @@ before-all = [
 
 [tool.cibuildwheel.pyodide]
 test-command = "pytest --pyargs skimage tests"
+test-extras = ["test"]


### PR DESCRIPTION
Fixes #8136.

The original `test-pyodide.yml` was copied from `numpy` in 2024.  They have since simplified the [workflow](https://github.com/numpy/numpy/blob/main/.github/workflows/emscripten.yml) to use `cibuildwheel` to do the environment setup.  This will make it easier to maintain on our end.