### PR TITLE
Add pip-only dependencies to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,12 @@ dependencies:
   # base
   - numpy>=2.1
   - scipy>=1.15
-  - scipy>=1.14
+  - networkx>=3.0
+  - pillow>=10.1
+  - imageio>=2.33,!=2.35.0
+  - tifffile>=2025.1.10
+  - packaging>=24
+  - lazy-loader>=0.5
   # build
   - meson-python>=0.16
   - ninja>=1.11.1.1

--- a/environment.yml
+++ b/environment.yml
@@ -5,12 +5,7 @@ dependencies:
   # base
   - numpy>=2.1
   - scipy>=1.15
-  - networkx>=3.0
-  - pillow>=10.1
-  - imageio>=2.33,!=2.35.0
-  - tifffile>=2025.1.10
-  - packaging>=24
-  - lazy-loader>=0.5
+  - scipy>=1.14
   # build
   - meson-python>=0.16
   - ninja>=1.11.1.1
@@ -24,7 +19,6 @@ dependencies:
   # developer
   - pre-commit
   - ipython
-  - docstub==0.7.0rc0
   # asv
   - asv
   # docs
@@ -69,3 +63,7 @@ dependencies:
   - pytest-localserver
   - pytest-faulthandler
   - pytest-doctestplus>=1.6.0
+  # pypa-only packages
+  - pip
+  - pip:
+      - docstub==0.7.0rc0

--- a/tools/generate_requirements.py
+++ b/tools/generate_requirements.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """Generate requirements/*.txt files from pyproject.toml.
 
-Also builda a conda environment.yml
+Also builds a conda environment.yml
 """
 
 import sys
@@ -72,8 +72,9 @@ def generate_environment_yml(req_sections: dict[str, list[str]]) -> None:
             lines.append(tab + f"  - {dep}")
 
             # Strip duplicates
-            if re.split('[>=]', lines[-2])[0] == re.split('[>=]', lines[-1])[0]:
-                lines = lines[:-1]
+            if len(lines) > 1 and lines[-2].startswith(tab + "  - "):
+                if re.split('[>=]', lines[-2])[0] == re.split('[>=]', lines[-1])[0]:
+                    lines.pop()
 
     for section in req_sections:
         _section_to_lst(section, req_sections, lines)

--- a/tools/generate_requirements.py
+++ b/tools/generate_requirements.py
@@ -41,9 +41,17 @@ def generate_environment_yml(req_sections: dict[str, list[str]]) -> None:
         'astropy': 'astropy-base',
         'matplotlib': 'matplotlib-base',
     }
+    pip_only = ['docstub']
+
     lines = ["name: skimage-dev", "channels:", "  - conda-forge", "dependencies:"]
-    for section in req_sections:
-        lines.append(f"  # {section}")
+    pip_section = {None: []}
+
+    def _section_to_lst(
+        section: str, req_sections: dict[str, list[str]], lines, offset=0
+    ):
+        tab = offset * " "
+        if section:
+            lines.append(tab + f"  # {section}")
         for dep in req_sections[section]:
             # Remove optional specifiers such as `[parallel]`
             dep = re.sub('\\[.*?\\]', '', dep)
@@ -56,11 +64,25 @@ def generate_environment_yml(req_sections: dict[str, list[str]]) -> None:
             if dep == "scikit-image":
                 continue
 
-            lines.append(f"  - {dep}")
+            if section and pkgname in pip_only:
+                if dep not in pip_section[None]:
+                    pip_section[None].append(dep)
+                continue
+
+            lines.append(tab + f"  - {dep}")
 
             # Strip duplicates
             if re.split('[>=]', lines[-2])[0] == re.split('[>=]', lines[-1])[0]:
                 lines = lines[:-1]
+
+    for section in req_sections:
+        _section_to_lst(section, req_sections, lines)
+
+    if pip_section[None]:
+        lines.append('  # pypa-only packages')
+        lines.append('  - pip')
+        lines.append('  - pip:')
+        _section_to_lst(None, pip_section, lines, offset=4)
 
     with open("environment.yml", "w") as f:
         f.writelines(f"{line}\n" for line in lines)

--- a/tools/generate_requirements.py
+++ b/tools/generate_requirements.py
@@ -47,7 +47,7 @@ def generate_environment_yml(req_sections: dict[str, list[str]]) -> None:
     pip_section = {None: []}
 
     def _section_to_lst(
-        section: str, req_sections: dict[str, list[str]], lines, offset=0
+        section: str | None, req_sections: dict[str, list[str]], lines, offset=0
     ):
         tab = offset * " "
         if section:
@@ -60,13 +60,14 @@ def generate_environment_yml(req_sections: dict[str, list[str]]) -> None:
             dep = re.sub('; .*', '', dep)
 
             pkgname = re.split('[>=]', dep)[0]
-            dep = dep.replace(pkgname, rename_idx.get(pkgname, pkgname))
-            if dep == "scikit-image":
-                continue
 
             if section and pkgname in pip_only:
                 if dep not in pip_section[None]:
                     pip_section[None].append(dep)
+                continue
+
+            dep = dep.replace(pkgname, rename_idx.get(pkgname, pkgname))
+            if dep == "scikit-image":
                 continue
 
             lines.append(tab + f"  - {dep}")


### PR DESCRIPTION
Maria Telenczuk wrote on Zulip:

> just a quick note that following the tutorial I had issues building the conda environment (for devs) due to condaforge not finding docstub==0.7.0rc0. I bypassed it by installing it via pip, but I thought it might be worth mentioning it to you

This change fixes the environment.yml to install docstub from pypa (there is no conda package).

Closes https://github.com/scikit-image/scikit-image/issues/8213