### PR TITLE
Drop Python 3.11 Support

### DIFF
--- a/.github/workflows/test-linux.yaml
+++ b/.github/workflows/test-linux.yaml
@@ -13,11 +13,6 @@ permissions:
 jobs:
   # GH does not support creating separate jobs out of a matrix,
   # so this is a workaround
-  build-linux-311:
-    uses: ./.github/workflows/_build_linux_for_python_x.yaml
-    with:
-      python-version: 3.11
-
   build-linux-312:
     uses: ./.github/workflows/_build_linux_for_python_x.yaml
     with:
@@ -38,31 +33,6 @@ jobs:
     with:
       python-version: 3.14t
 
-  test-linux-311:
-    name: test-linux-cp3.11-${{ matrix.OPTIONS_NAME }}
-    needs: [build-linux-311]
-    strategy:
-      fail-fast: false
-      matrix:
-        OPTIONS_NAME: ["main"]
-
-        include:
-          # Dependency options for setup-test-env.sh
-          - MINIMUM_REQUIREMENTS: 1
-            OPTIONAL_DEPS: 0
-            EAGER_IMPORT: 1
-            OPTIONS_NAME: "mini-req-eager-import"
-          - MINIMUM_REQUIREMENTS: 1
-            OPTIONAL_DEPS: 1
-            OPTIONS_NAME: "mini-req-optional-deps"
-    uses: ./.github/workflows/_test_linux_for_python_x.yaml
-    with:
-      python-version: 3.11
-      OPTIONS_NAME: ${{ matrix.OPTIONS_NAME }}
-      MINIMUM_REQUIREMENTS: ${{ matrix.MINIMUM_REQUIREMENTS }}
-      OPTIONAL_DEPS: ${{ matrix.OPTIONAL_DEPS }}
-      EAGER_IMPORT: ${{ matrix.EAGER_IMPORT }}
-
   test-linux-312:
     name: test-linux-cp3.12-${{ matrix.OPTIONS_NAME }}
     needs: [build-linux-312]
@@ -82,12 +52,21 @@ jobs:
             OPTIONS_NAME: "optimize-and-no-pooch"
           - INSTALL_FROM_SDIST: 1
             OPTIONS_NAME: "install-from-sdist"
+          - MINIMUM_REQUIREMENTS: 1
+            OPTIONAL_DEPS: 0
+            EAGER_IMPORT: 1
+            OPTIONS_NAME: "mini-req-eager-import"
+          - MINIMUM_REQUIREMENTS: 1
+            OPTIONAL_DEPS: 1
+            OPTIONS_NAME: "mini-req-optional-deps"
 
     uses: ./.github/workflows/_test_linux_for_python_x.yaml
     with:
       python-version: 3.12
       OPTIONS_NAME: ${{ matrix.OPTIONS_NAME }}
+      MINIMUM_REQUIREMENTS: ${{ matrix.MINIMUM_REQUIREMENTS }}
       OPTIONAL_DEPS: ${{ matrix.OPTIONAL_DEPS }}
+      EAGER_IMPORT: ${{ matrix.EAGER_IMPORT }}
       WITHOUT_POOCH: ${{ matrix.WITHOUT_POOCH }}
       PIP_FLAGS: ${{ matrix.PIP_FLAGS }}
       PYTHONOPTIMIZE: ${{ matrix.PYTHONOPTIMIZE }}
@@ -121,12 +100,10 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       [
-        build-linux-311,
         build-linux-312,
         build-linux-313,
         build-linux-314,
         build-linux-314t,
-        test-linux-311,
         test-linux-312,
         test-linux-313,
         test-linux-314,

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -23,7 +23,7 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.13"]
+        python-version: ["3.12", "3.13"]
         os: [macos-latest]
         OPTIONAL_DEPS: [1]
         OPTIONS_NAME: ["default"]

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -23,7 +23,7 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.12", "3.14"]
         os: [macos-latest]
         OPTIONAL_DEPS: [1]
         OPTIONS_NAME: ["default"]

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -30,14 +30,14 @@ jobs:
             MINIMUM_REQUIREMENTS: 0
             OPTIONAL_DEPS: 0
             OPTIONS_NAME: "default"
-          - python-version: "3.14"
+          - python-version: "3.12"
             MINIMUM_REQUIREMENTS: 0
             OPTIONAL_DEPS: 1
             OPTIONS_NAME: "optional-deps"
-          - python-version: "3.12"
+          - python-version: "3.13"
             PIP_FLAGS: "--pre"
             OPTIONS_NAME: "pre"
-          - python-version: "3.13"
+          - python-version: "3.14"
             MINIMUM_REQUIREMENTS: 0
             OPTIONAL_DEPS: 0
             OPTIONS_NAME: "default"

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -26,11 +26,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.11"
+          - python-version: "3.12"
             MINIMUM_REQUIREMENTS: 0
             OPTIONAL_DEPS: 0
             OPTIONS_NAME: "default"
-          - python-version: "3.11"
+          - python-version: "3.14"
             MINIMUM_REQUIREMENTS: 0
             OPTIONAL_DEPS: 1
             OPTIONS_NAME: "optional-deps"

--- a/.github/workflows/wheels-recipe.yaml
+++ b/.github/workflows/wheels-recipe.yaml
@@ -22,7 +22,7 @@ jobs:
             macos-15-intel,
             macos-latest, # ARM-version of MacOS
           ]
-        build: ["cp31{1,2}*", "cp313*", "cp314*"]
+        build: ["cp312*", "cp313*", "cp314*"]
 
     steps:
       - uses: actions/checkout@v5
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, windows-11-arm]
-        build: ["cp31{1,2}*", "cp313*", "cp314*"]
+        build: ["cp312*", "cp313*", "cp314*"]
 
     steps:
       - uses: actions/checkout@v5
@@ -77,10 +77,10 @@ jobs:
         os: [ubuntu-latest, ubuntu-22.04-arm]
         build:
           [
-            "cp31{1,2}*manylinux*",
+            "cp312*manylinux*",
             "cp313*manylinux*",
             "cp314*manylinux*",
-            "cp31{1,2}*musllinux*",
+            "cp312*musllinux*",
             "cp313*musllinux*",
             "cp314*musllinux*",
           ]

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -66,7 +66,7 @@ A virtual environment creates a clean Python environment that does not interfere
 with the existing system installation, can be easily removed, and contains only
 the package versions your application needs.
 
-To install the current ``scikit-image`` you'll need at least Python 3.11. If
+To install the current ``scikit-image`` you'll need at least Python 3.12. If
 your Python is older, pip will find the most recent compatible version.
 
 .. code-block:: sh

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -82,10 +82,6 @@ File: skimage/transform/_thin_plate_splines.py
 Copyright: 2007 Zachary Pincus
 License: BSD-3-Clause
 
-Function: skimage/_shared/_warnings.py:warn_external
-Copyright: 2012-2025 Matplotlib Development Team
-License: PSF-2.0
-
 License: BSD-2-Clause
 
 Redistribution and use in source and binary forms, with or without
@@ -154,53 +150,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-
-License: PSF-2.0
-
-1. This LICENSE AGREEMENT is between the Matplotlib Development Team
-("MDT"), and the Individual or Organization ("Licensee") accessing and
-otherwise using matplotlib software in source or binary form and its
-associated documentation.
-
-2. Subject to the terms and conditions of this License Agreement, MDT
-hereby grants Licensee a nonexclusive, royalty-free, world-wide license
-to reproduce, analyze, test, perform and/or display publicly, prepare
-derivative works, distribute, and otherwise use matplotlib
-alone or in any derivative version, provided, however, that MDT's
-License Agreement and MDT's notice of copyright, i.e., "Copyright (c)
-2012- Matplotlib Development Team; All Rights Reserved" are retained in
-matplotlib  alone or in any derivative version prepared by
-Licensee.
-
-3. In the event Licensee prepares a derivative work that is based on or
-incorporates matplotlib or any part thereof, and wants to
-make the derivative work available to others as provided herein, then
-Licensee hereby agrees to include in any such work a brief summary of
-the changes made to matplotlib .
-
-4. MDT is making matplotlib available to Licensee on an "AS
-IS" basis.  MDT MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
-IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, MDT MAKES NO AND
-DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
-FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF MATPLOTLIB
-WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
-
-5. MDT SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF MATPLOTLIB
- FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR
-LOSS AS A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING
-MATPLOTLIB , OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF
-THE POSSIBILITY THEREOF.
-
-6. This License Agreement will automatically terminate upon a material
-breach of its terms and conditions.
-
-7. Nothing in this License Agreement shall be deemed to create any
-relationship of agency, partnership, or joint venture between MDT and
-Licensee.  This License Agreement does not grant permission to use MDT
-trademarks or trade name in a trademark sense to endorse or promote
-products or services of Licensee, or any third party.
-
-8. By copying, installing or otherwise using matplotlib ,
-Licensee agrees to be bound by the terms and conditions of this License
-Agreement.

--- a/TODO.txt
+++ b/TODO.txt
@@ -45,11 +45,6 @@ Other
   `skimage/graph/_graph_cut.py::_ncut_relabel` and the `xfail` mark in
   `tests/skimage/graph/test_rag.py::test_reproducibility`.
 
-Post Python 3.11
-----------------
-* Remove or simplify `skimage._shared._warnings::warn_external` to use only
-  `skip_file_prefixes`. Remove corresponding license code in LICENSE.txt (if possible).
-
 Post Python 3.12
 ----------------
 * Remove `sys.version_info` checks in

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -11,7 +11,7 @@
     "install_timeout": 1200,
     "show_commit_url": "https://github.com/scikit-image/scikit-image/commit/",
 
-    "pythons": ["3.11"],
+    "pythons": ["3.12"],
     "matrix": {
          "virtualenv": [],
          "cython": [],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = 'scikit-image'
 description = 'Image processing in Python'
-requires-python = '>=3.11'
+requires-python = '>=3.12'
 readme = 'README.md'
 classifiers = [
     'Development Status :: 4 - Beta',
@@ -12,7 +12,6 @@ classifiers = [
     'Programming Language :: C',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
     'Programming Language :: Python :: 3.14',

--- a/src/_skimage2/_shared/_warnings.py
+++ b/src/_skimage2/_shared/_warnings.py
@@ -164,33 +164,14 @@ def warn_external(message, *, category=None):
     category : type[Warning]
         The class used in the warning.
     """
-    kwargs = {}
-    if sys.version_info[:2] >= (3, 12):
-        # Go to Python's `site-packages` or `lib` from an editable install.
-        basedir = Path(__file__).parents[2]
-        kwargs['skip_file_prefixes'] = (
+    # Go to Python's `site-packages` or `lib` from an editable install.
+    basedir = Path(__file__).parents[2]
+    warnings.warn(
+        message,
+        category,
+        skip_file_prefixes=(
             str(basedir / 'skimage'),
             str(basedir / 'skimage2'),
             str(basedir / '_skimage2'),
-        )
-    else:
-        frame = sys._getframe()
-        # finite counter in case of error in break logic
-        counter = range(1, sys.getrecursionlimit() + 1)
-        for stacklevel in counter:
-            if frame is None:
-                # when called in embedded context may hit frame is None
-                kwargs['stacklevel'] = stacklevel
-                break
-            in_skimage_namespace = re.match(
-                r"\A_?skimage(2)?(\Z|\.)",
-                # Work around sphinx-gallery not setting __name__.
-                frame.f_globals.get("__name__", ""),
-            )
-            if not in_skimage_namespace:
-                kwargs['stacklevel'] = stacklevel
-                break
-            frame = frame.f_back
-        # preemptively break reference cycle between locals and the frame
-        del frame
-    warnings.warn(message, category, **kwargs)
+        ),
+    )

--- a/tools/generate_requirements.py
+++ b/tools/generate_requirements.py
@@ -4,17 +4,10 @@
 Also builda a conda environment.yml
 """
 
-import sys
 import re
 from pathlib import Path
 
-try:  # standard module since Python 3.11
-    import tomllib as toml
-except ImportError:
-    try:  # available for older Python via pip
-        import tomli as toml
-    except ImportError:
-        sys.exit("Please install `tomli` first: `pip install tomli`")
+import tomllib as toml
 
 script_pth = Path(__file__)
 repo_dir = script_pth.parent.parent


### PR DESCRIPTION
## Drop Python 3.11 support

  Python 3.11 has reached the end of its support window for this project. This PR removes all 3.11 CI jobs, test matrix entries, and wheel builds, and bumps the minimum required version to 3.12.

### Changes

  **Configuration**
  - `pyproject.toml`: bump `requires-python` to `>=3.12`, remove 3.11 classifier
  - `INSTALL.rst`: update documented minimum Python version to 3.12
  - `asv.conf.json`: update benchmark Python to 3.12

  **CI**
  - `test-linux.yaml`: remove `build-linux-311` / `test-linux-311` jobs; move `mini-req-eager-import` and `mini-req-optional-deps` matrix variants into the 3.12 job
  - `test-macos.yaml`: replace 3.11 and 3.13 matrix entries with 3.12 and 3.14
  - `test-windows.yaml`: replace two 3.11 entries with 3.12
  - `wheels-recipe.yaml`: replace `cp31{1,2}*` with `cp312*` throughout

  **Code simplifications**
  - `src/_skimage2/_shared/_warnings.py`: remove `sys.version_info >= (3, 12)` branch in `warn_external`; always use `skip_file_prefixes` (3.12+ only API)
  - `tools/generate_requirements.py`: replace `try/except tomllib/tomli` fallback with a direct `import tomllib` (standard since 3.11)

  **Licensing**
  - `LICENSE.txt`: remove the `warn_external` function entry and the PSF-2.0 license section, which covered the now-deleted stack-walking code

### AI Usage

This PR was developed with the assistance of Claude Code (claude-sonnet-4-6).
I (@blink1073) have thoroughly reviewed the changes.