### PR TITLE
Fix minkowski distanced invocation for SciPy >= 1.18

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -44,6 +44,8 @@ Other
   `scipy.linalg.eigsh` is available everywhere, remove the compatibility logic in
   `skimage/graph/_graph_cut.py::_ncut_relabel` and the `xfail` mark in
   `tests/skimage/graph/test_rag.py::test_reproducibility`.
+* Once SciPy 1.18 is minimal required version, remove minkowski
+  distance branching from `src/skimage/measure/fit.py`.
 
 Post Python 3.11
 ----------------

--- a/src/skimage/measure/fit.py
+++ b/src/skimage/measure/fit.py
@@ -623,7 +623,11 @@ class CircleModel(_BaseModel):
             )
 
         center = C[0:2]
-        distances = spatial.minkowski_distance(center, data)
+        # Can remove once SciPy 1.18 is the default
+        if hasattr(spatial, 'distance') and hasattr(spatial.distance, 'minkowski'):
+            distances = spatial.distance.minkowski(center, data)
+        else:
+            distances = spatial.minkowski_distance(center, data)
         r = np.sqrt(np.mean(distances**2))
 
         # Revert normalization and set init params.

--- a/src/skimage/measure/fit.py
+++ b/src/skimage/measure/fit.py
@@ -5,7 +5,8 @@ from warnings import warn, catch_warnings
 
 import numpy as np
 from numpy.linalg import inv
-from scipy import optimize, spatial
+from packaging import version
+import scipy
 
 from _skimage2._shared.utils import (
     _deprecate_estimate,
@@ -624,10 +625,10 @@ class CircleModel(_BaseModel):
 
         center = C[0:2]
         # Can remove once SciPy 1.18 is the default
-        if hasattr(spatial, 'distance') and hasattr(spatial.distance, 'minkowski'):
-            distances = spatial.distance.minkowski(center, data)
+        if version.parse(scipy.__version__) >= version.parse('1.18.0dev0'):
+            distances = scipy.spatial.distance.minkowski(center, data)
         else:
-            distances = spatial.minkowski_distance(center, data)
+            distances = scipy.spatial.minkowski_distance(center, data)
         r = np.sqrt(np.mean(distances**2))
 
         # Revert normalization and set init params.
@@ -1039,7 +1040,7 @@ class EllipseModel(_BaseModel):
             xi = x[i]
             yi = y[i]
             # faster without Dfun, because of the python overhead
-            t, _ = optimize.leastsq(fun, t0[i], args=(xi, yi))
+            t, _ = scipy.optimize.leastsq(fun, t0[i], args=(xi, yi))
             residuals[i] = np.sqrt(fun(t, xi, yi))
 
         return residuals


### PR DESCRIPTION
SciPy now raises a warning for `spatial.minkowski_distance`, need to use `spatial.distance.minkowski` instead.

Without this fix, we don't build nightlies.