### PR TITLE
make spin build requirement a lower bound

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - Cython>=3.0.10,!=3.2.0b1
   - pythran>=0.16
   - numpy>=2.0
-  - spin==0.13
+  - spin>=0.13
   - python-build>=1.2.1
   # data
   - pooch>=1.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ build = [
     'pythran>=0.16',
     'numpy>=2.0',
     # Developer UI
-    'spin==0.13',
+    'spin>=0.13',
     'build>=1.2.1',
 ]
 data = ['pooch>=1.6.0']

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -5,5 +5,5 @@ ninja>=1.11.1.1
 Cython>=3.0.10,!=3.2.0b1
 pythran>=0.16
 numpy>=2.0
-spin==0.13
+spin>=0.13
 build>=1.2.1


### PR DESCRIPTION
While working on #8065 I noticed that I had a kinda old spin version installed. IMO spin is stable enough you can mark this as a lower bound. Let's see if CI agrees.