### PR TITLE
Static inline for `__inline`

### DIFF
--- a/src/_skimage2/_shared/fast_exp.h
+++ b/src/_skimage2/_shared/fast_exp.h
@@ -14,7 +14,7 @@
 /* For min. mean relative error */
 /* #define EXP_BC 1072625005 */        /* 1023*2^20 - 68243 */
 
-__inline double _fast_exp (double y)
+static inline double _fast_exp (double y)
 {
     union
     {
@@ -41,7 +41,7 @@ __inline double _fast_exp (double y)
     return _eco.d;
 }
 
-__inline float _fast_expf (float y)
+static inline float _fast_expf (float y)
 {
   return (float)_fast_exp((double)y);
 }


### PR DESCRIPTION
Change suggested in another patch by Gemini.

Quick research suggests this change is reasonable:

* https://gcc.gnu.org/onlinedocs/gcc-3.3.6/gcc/Inline.html
* https://learn.microsoft.com/en-us/cpp/c-language/inline-functions?view=msvc-170&redirectedfrom=MSDN

but I am happy to defer to someone with more expertise.
