### PR TITLE
Fix structural_similarity win_size / gaussian_weights conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,6 +219,8 @@ filterwarnings = [
     "error",
     "ignore::skimage.util.PendingSkimage2Change",
     "ignore:.*use `imageio` or other I/O packages directly.*:FutureWarning",
+    # Passing win_size with gaussian_weights=True is deprecated
+    "ignore:.*win_size.*gaussian_weights.*:FutureWarning",
     # warn by pyamg in ruge_stuben_solver
     "ignore:Implicit conversion of A to CSR:scipy.sparse.SparseEfficiencyWarning",
     # Pyodide warning coming via threadpoolctl, remove when

--- a/src/_skimage2/metrics/_structural_similarity.py
+++ b/src/_skimage2/metrics/_structural_similarity.py
@@ -36,9 +36,10 @@ def structural_similarity(
         The data range of the input image (difference between maximum and
         minimum possible values).
     win_size : int or None, optional
-        The side-length of the sliding window used in comparison. Must be an
-        odd value. If `gaussian_weights` is True, `win_size` cannot be
-        specified since the window size is then determined by `sigma`.
+        The side-length of the sliding window used in comparisons
+        (default: 7). Must be an odd value. If `gaussian_weights` is
+        True, `win_size` cannot be specified since the window size is
+        then determined by `sigma`.
     gradient : bool, optional
         If True, also return the gradient with respect to im2.
     channel_axis : int or None, optional

--- a/src/_skimage2/metrics/_structural_similarity.py
+++ b/src/_skimage2/metrics/_structural_similarity.py
@@ -37,8 +37,8 @@ def structural_similarity(
         minimum possible values).
     win_size : int or None, optional
         The side-length of the sliding window used in comparison. Must be an
-        odd value. If `gaussian_weights` is True, this is ignored and the
-        window size will depend on `sigma`.
+        odd value. If `gaussian_weights` is True, `win_size` cannot be
+        specified since the window size is then determined by `sigma`.
     gradient : bool, optional
         If True, also return the gradient with respect to im2.
     channel_axis : int or None, optional
@@ -46,8 +46,8 @@ def structural_similarity(
         Otherwise, this parameter indicates which axis of the array corresponds
         to channels.
     gaussian_weights : bool, optional
-        If True, each patch has its mean and variance spatially weighted by a
-        normalized Gaussian kernel of width sigma=1.5.
+        If True, the local mean and variance are computed using a normalized
+        Gaussian kernel of width `sigma` rather than a uniform window.
     full : bool, optional
         If True, also return the full structural similarity image.
     use_sample_covariance : bool, optional
@@ -59,6 +59,7 @@ def structural_similarity(
         Algorithm parameter, K2 (small constant, see [1]_).
     sigma : float, optional
         Standard deviation for the Gaussian when `gaussian_weights` is True.
+        Default is 1.5.
 
     Returns
     -------
@@ -169,14 +170,17 @@ def structural_similarity(
         # Set to give an 11-tap filter with the default sigma of 1.5 to match
         # Wang et. al. 2004.
         truncate = 3.5
-
-    if win_size is None:
-        if gaussian_weights:
-            # set win_size used by crop to match the filter size
-            r = int(truncate * sigma + 0.5)  # radius as in ndimage
-            win_size = 2 * r + 1
-        else:
-            win_size = 7  # backwards compatibility
+        if win_size is not None:
+            raise ValueError(
+                "win_size cannot be specified when gaussian_weights is True; "
+                "the window size is determined by sigma. "
+                "Use sigma to control the effective window size."
+            )
+        # derive win_size from sigma for padding and normalization
+        r = int(truncate * sigma + 0.5)  # radius as in ndimage
+        win_size = 2 * r + 1
+    elif win_size is None:
+        win_size = 7  # backwards compatibility
 
     if np.any((np.asarray(im1.shape) - win_size) < 0):
         raise ValueError(

--- a/src/skimage/metrics/_structural_similarity.py
+++ b/src/skimage/metrics/_structural_similarity.py
@@ -64,10 +64,10 @@ def structural_similarity(
     im1, im2 : ndarray
         Images. Any dimensionality with same shape.
     win_size : int or None, optional
-        The side-length of the sliding window used in comparison. Must be an
-        odd value. If `gaussian_weights` is True, `win_size` cannot be
-        specified; the window size is determined by `sigma`. Passing both
-        is deprecated and will raise an error in a future version.
+        The side-length of the sliding window used in comparisons
+        (default: 7). Must be an odd value. If `gaussian_weights` is
+        True, `win_size` cannot be specified since the window size is
+        determined by `sigma`.
     gradient : bool, optional
         If True, also return the gradient with respect to im2.
     data_range : float, optional

--- a/src/skimage/metrics/_structural_similarity.py
+++ b/src/skimage/metrics/_structural_similarity.py
@@ -65,8 +65,9 @@ def structural_similarity(
         Images. Any dimensionality with same shape.
     win_size : int or None, optional
         The side-length of the sliding window used in comparison. Must be an
-        odd value. If `gaussian_weights` is True, this is ignored and the
-        window size will depend on `sigma`.
+        odd value. If `gaussian_weights` is True, `win_size` cannot be
+        specified; the window size is determined by `sigma`. Passing both
+        is deprecated and will raise an error in a future version.
     gradient : bool, optional
         If True, also return the gradient with respect to im2.
     data_range : float, optional
@@ -83,8 +84,8 @@ def structural_similarity(
         .. versionadded:: 0.19
            ``channel_axis`` was added in 0.19.
     gaussian_weights : bool, optional
-        If True, each patch has its mean and variance spatially weighted by a
-        normalized Gaussian kernel of width sigma=1.5.
+        If True, the local mean and variance are computed using a normalized
+        Gaussian kernel of width `sigma` rather than a uniform window.
     full : bool, optional
         If True, also return the full structural similarity image.
 
@@ -99,6 +100,7 @@ def structural_similarity(
         Algorithm parameter, K2 (small constant, see [1]_).
     sigma : float
         Standard deviation for the Gaussian when `gaussian_weights` is True.
+        Default is 1.5.
 
     Returns
     -------
@@ -168,6 +170,19 @@ def structural_similarity(
                 + f"data_range = {data_range:.0f}. "
                 + "Please specify data_range explicitly to avoid mistakes.",
             )
+
+    if gaussian_weights and win_size is not None:
+        import warnings
+
+        warnings.warn(
+            "Passing win_size with gaussian_weights=True is deprecated "
+            "and will raise an error in a future version. The window "
+            "size is determined by sigma; use sigma to control the "
+            "effective window size.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        win_size = None  # let _skimage2 derive it from sigma
 
     return ski2.metrics.structural_similarity(
         im1,

--- a/src/skimage/metrics/_structural_similarity.py
+++ b/src/skimage/metrics/_structural_similarity.py
@@ -172,15 +172,12 @@ def structural_similarity(
             )
 
     if gaussian_weights and win_size is not None:
-        import warnings
-
-        warnings.warn(
+        warn_external(
             "Passing win_size with gaussian_weights=True is deprecated "
             "and will raise an error in a future version. The window "
             "size is determined by sigma; use sigma to control the "
             "effective window size.",
-            FutureWarning,
-            stacklevel=2,
+            category=FutureWarning,
         )
         win_size = None  # let _skimage2 derive it from sigma
 

--- a/tests/skimage/metrics/test_structural_similarity.py
+++ b/tests/skimage/metrics/test_structural_similarity.py
@@ -308,6 +308,16 @@ def test_structural_similarity_estimate_data_range(dtype):
     assert result_explicit == result_estimated
 
 
+def test_gaussian_weights_win_size_future_warning():
+    """Passing win_size with gaussian_weights=True is deprecated (#7231)."""
+    N = 100
+    X = (np.random.rand(N, N) * 255).astype(np.uint8)
+    Y = (np.random.rand(N, N) * 255).astype(np.uint8)
+
+    with pytest.warns(FutureWarning, match="win_size.*gaussian_weights"):
+        structural_similarity(X, Y, gaussian_weights=True, win_size=101)
+
+
 def test_invalid_input():
     # size mismatch
     X = np.zeros((9, 9), dtype=np.float64)

--- a/tests/skimage/metrics/test_structural_similarity.py
+++ b/tests/skimage/metrics/test_structural_similarity.py
@@ -37,7 +37,7 @@ def test_structural_similarity_image():
     S1 = structural_similarity(X, Y, win_size=3)
     assert S1 < 0.3
 
-    S2 = structural_similarity(X, Y, win_size=11, gaussian_weights=True)
+    S2 = structural_similarity(X, Y, gaussian_weights=True)
     assert S2 < 0.3
 
     mssim0, S3 = structural_similarity(X, Y, full=True)

--- a/tests/skimage/metrics/test_structural_similarity.py
+++ b/tests/skimage/metrics/test_structural_similarity.py
@@ -314,8 +314,8 @@ def test_gaussian_weights_win_size_future_warning():
     X = (np.random.rand(N, N) * 255).astype(np.uint8)
     Y = (np.random.rand(N, N) * 255).astype(np.uint8)
 
-    with pytest.warns(FutureWarning, match="win_size.*gaussian_weights"):
-        structural_similarity(X, Y, gaussian_weights=True, win_size=101)
+    with pytest.warns(FutureWarning, match="Passing win_size with gaussian_weights"):
+        structural_similarity(X, Y, gaussian_weights=True, win_size=7)
 
 
 def test_invalid_input():

--- a/tests/skimage2/metrics/test_structural_similarity.py
+++ b/tests/skimage2/metrics/test_structural_similarity.py
@@ -36,7 +36,7 @@ def test_structural_similarity_image():
     S1 = structural_similarity(X, Y, data_range=255, win_size=3)
     assert S1 < 0.3
 
-    S2 = structural_similarity(X, Y, data_range=255, win_size=11, gaussian_weights=True)
+    S2 = structural_similarity(X, Y, data_range=255, gaussian_weights=True)
     assert S2 < 0.3
 
     mssim0, S3 = structural_similarity(X, Y, data_range=255, full=True)

--- a/tests/skimage2/metrics/test_structural_similarity.py
+++ b/tests/skimage2/metrics/test_structural_similarity.py
@@ -291,6 +291,16 @@ def test_structural_similarity_errors_without_data_range():
         structural_similarity(X, X)
 
 
+def test_gaussian_weights_win_size_error():
+    """win_size with gaussian_weights=True should raise ValueError (#7231)."""
+    N = 100
+    X = (np.random.rand(N, N) * 255).astype(np.uint8)
+    Y = (np.random.rand(N, N) * 255).astype(np.uint8)
+
+    with pytest.raises(ValueError, match="win_size.*gaussian_weights"):
+        structural_similarity(X, Y, data_range=255, gaussian_weights=True, win_size=101)
+
+
 def test_invalid_input():
     X = np.zeros((9, 9), dtype=np.float64)
     Y = np.zeros((8, 8), dtype=np.float64)

--- a/tests/skimage2/metrics/test_structural_similarity.py
+++ b/tests/skimage2/metrics/test_structural_similarity.py
@@ -297,8 +297,10 @@ def test_gaussian_weights_win_size_error():
     X = (np.random.rand(N, N) * 255).astype(np.uint8)
     Y = (np.random.rand(N, N) * 255).astype(np.uint8)
 
-    with pytest.raises(ValueError, match="win_size.*gaussian_weights"):
-        structural_similarity(X, Y, data_range=255, gaussian_weights=True, win_size=101)
+    with pytest.raises(
+        ValueError, match="win_size cannot be specified when gaussian_weights"
+    ):
+        structural_similarity(X, Y, data_range=255, gaussian_weights=True, win_size=7)
 
 
 def test_invalid_input():


### PR DESCRIPTION
When `gaussian_weights=True`, the window size should be calculated
automatically based on sigma. However, in skimage1 we allowed
`win_size` to override it. Raise a ValueError in v2, and warn in v1
when these are used together.

I also corrected an awkward phrasing in the docs: it previously said
that the mean and variance are "spatially weighted by" a Gaussian
kernel, whereas they are are *computed using* the Gaussian window.

The `sigma` parameter description is updated to document its default
value (1.5).

Closes #7231

Assisted-by: GLM:glm-5.1
@stefanv reviewed each line of code.