### PR TITLE
ci: Remove llvm build and add ccache support on windows

### DIFF
--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -81,6 +81,10 @@ jobs:
         run: |
           spin build
 
+      - name: Show ccache stats
+        shell: bash
+        run: ccache --show-stats
+
       - name: Install test dependencies
         env:
           MINIMUM_REQUIREMENTS: ${{ matrix.MINIMUM_REQUIREMENTS }}

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -12,8 +12,9 @@ permissions:
   issues: write
 
 env:
-  CC: clang
-  CXX: clang
+  CC: ccache clang
+  CXX: ccache clang
+  CCACHE_DIR: C:\ccache
 
 jobs:
   test_skimage_windows:
@@ -62,16 +63,18 @@ jobs:
         run: |
           source .github/scripts/setup-build-env.sh
 
-      # Please review frequently to see if it is still necessary.
-      # MSVC STL requires later clang than default on image.
-      # https://github.com/actions/runner-images/issues/12435#issuecomment-2997654523
-      - name: Install LLVM Clang 19 on Windows
-        shell: powershell
-        run: |
-          $ErrorActionPreference = "Stop"
-          Invoke-WebRequest -Uri "https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/LLVM-19.1.7-win64.exe" -OutFile "llvm.exe"
-          Start-Process -FilePath .\llvm.exe -ArgumentList "/S", "/D=C:\LLVM" -Wait
-          echo "C:\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Install ccache
+        shell: bash
+        run: choco install ccache --no-progress
+
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.OPTIONS_NAME }}-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.OPTIONS_NAME }}-
+            ccache-${{ runner.os }}-
 
       - name: Build skimage
         shell: bash


### PR DESCRIPTION
Fixes #8146 and addresses TODO from https://github.com/scikit-image/scikit-image/pull/7835

Attempt 1: 2m55s for build
Attempt 2:  1m35s

```
Run ccache --show-stats
Cacheable calls:    112 / 112 (100.0%)
  Hits:              56 / 112 (50.00%)
    Direct:          56 /  56 (100.0%)
    Preprocessed:     0 /  56 ( 0.00%)
  Misses:            56 / 112 (50.00%)
Local storage:
  Cache size (GiB): 0.0 / 5.0 ( 0.35%)
  Hits:              56 / 112 (50.00%)
  Misses:            56 / 112 (50.00%)
```

We have also removed the 8m52s LLVM build step from the latest run on [main](https://github.com/scikit-image/scikit-image/actions/runs/25875279842/job/76040728160).  The full run on main took 18m41s, while on the second attempt in this PR it took 3m32s.  About 5 minutes of that delta is from the `--test-modified` support added in #8103 