### PR TITLE
Feature/sort peak local max

### DIFF
--- a/src/_skimage2/feature/_peaks.py
+++ b/src/_skimage2/feature/_peaks.py
@@ -317,8 +317,9 @@ def peak_local_max(
     Returns
     -------
     output : ndarray of shape (N, D)
-        The coordinates of the peaks. ``N`` denotes the number of peaks and
-        ``D`` corresponds to the number of dimensions in `image`.
+        The coordinates of the peaks, sorted by descending peak intensity.
+        ``N`` denotes the number of peaks and ``D`` corresponds to the
+        number of dimensions in `image`.
 
     Notes
     -----

--- a/src/_skimage2/feature/_peaks.py
+++ b/src/_skimage2/feature/_peaks.py
@@ -1,6 +1,6 @@
 import numpy as np
 import scipy.ndimage as ndi
-from scipy.spatial import cKDTree, distance
+from scipy.spatial import cKDTree
 
 from .._shared._warnings import warn_external
 
@@ -32,27 +32,25 @@ def _batched_ensure_spacing(coord_batch, spacing, p_norm, max_out):
     tree = cKDTree(coord_batch)
 
     indices = tree.query_ball_point(coord_batch, r=spacing, p=p_norm)
-    rejected_peaks_indices = set()
+    rejected = np.zeros(len(coord_batch), dtype=bool)
     naccepted = 0
     for idx, candidates in enumerate(indices):
-        if idx not in rejected_peaks_indices:
-            # keep current point and the points at exactly spacing from it
-            candidates.remove(idx)
-            dist = distance.cdist(
-                [coord_batch[idx]], coord_batch[candidates], "minkowski", p=p_norm
-            ).reshape(-1)
-            candidates = [
-                c for c, d in zip(candidates, dist, strict=True) if d < spacing
-            ]
+        if not rejected[idx]:
+            # `query_ball_point` is inclusive (``d <= spacing``); re-filter
+            # to strict ``d < spacing`` so points exactly `spacing` apart
+            # are kept.
+            cand = np.array(candidates)
+            cand = cand[cand != idx]
+            if len(cand):
+                diff = coord_batch[cand] - coord_batch[idx]
+                dist = np.linalg.norm(diff, ord=p_norm, axis=1)
+                rejected[cand[dist < spacing]] = True
 
-            # candidates.remove(keep)
-            rejected_peaks_indices.update(candidates)
             naccepted += 1
             if max_out is not None and naccepted >= max_out:
                 break
 
-    # Remove the peaks that are too close to each other
-    output = np.delete(coord_batch, tuple(rejected_peaks_indices), axis=0)
+    output = coord_batch[~rejected]
     if max_out is not None:
         output = output[:max_out]
 

--- a/src/_skimage2/feature/_peaks.py
+++ b/src/_skimage2/feature/_peaks.py
@@ -142,26 +142,33 @@ def _ensure_spacing(
     return output
 
 
+def _filter_peaks(coords, intensities, num_peaks, min_distance, p_norm):
+    """Sort `coords` by descending `intensities`, enforce `min_distance`
+    spacing, and truncate to `num_peaks`.
+    """
+    if len(coords) == 0:
+        return coords
+    coords = coords[np.argsort(-intensities, stable=True)]
+
+    if min_distance > 1:
+        coords = _ensure_spacing(
+            coords, spacing=min_distance, p_norm=p_norm, max_out=num_peaks
+        )
+
+    if num_peaks is not None and len(coords) > num_peaks:
+        coords = coords[:num_peaks]
+
+    return coords
+
+
 def _get_high_intensity_peaks(image, mask, num_peaks, min_distance, p_norm):
     """
     Return the highest intensity peak coordinates.
     """
-    # get coordinates of peaks
-    coord = np.nonzero(mask)
-    intensities = image[coord]
-    # Highest peak first
-    idx_maxsort = np.argsort(-intensities, kind="stable")
-    coord = np.transpose(coord)[idx_maxsort]
-
-    if min_distance > 1:
-        coord = _ensure_spacing(
-            coord, spacing=min_distance, p_norm=p_norm, max_out=num_peaks
-        )
-
-    if num_peaks is not None and len(coord) > num_peaks:
-        coord = coord[:num_peaks]
-
-    return coord
+    coords = np.nonzero(mask)
+    intensities = image[coords]
+    coords = np.transpose(coords)
+    return _filter_peaks(coords, intensities, num_peaks, min_distance, p_norm)
 
 
 def _get_peak_mask(image, footprint, threshold, mask=None):
@@ -426,11 +433,12 @@ def peak_local_max(
         else:
             coordinates = np.empty((0, image.ndim), dtype=int)
 
-        if num_peaks is not None and len(coordinates) > num_peaks:
-            out = np.zeros_like(image, dtype=bool)
-            out[tuple(coordinates.T)] = True
-            coordinates = _get_high_intensity_peaks(
-                image, out, num_peaks, min_distance, p_norm
+        if len(coordinates):
+            # Globally sort by descending intensity so the labels path
+            # returns peaks in the same order as the labels=None path.
+            intensities = image[tuple(coordinates.T)]
+            coordinates = _filter_peaks(
+                coordinates, intensities, num_peaks, min_distance, p_norm
             )
 
     return coordinates

--- a/src/_skimage2/feature/_peaks.py
+++ b/src/_skimage2/feature/_peaks.py
@@ -421,8 +421,7 @@ def peak_local_max(
             )
 
             # transform coordinates in global image indices space
-            for idx, s in enumerate(roi):
-                coordinates[:, idx] += s.start
+            coordinates += [s.start for s in roi]
 
             labels_peak_coord.append(coordinates)
 

--- a/src/_skimage2/feature/_peaks.py
+++ b/src/_skimage2/feature/_peaks.py
@@ -140,33 +140,26 @@ def _ensure_spacing(
     return output
 
 
-def _filter_peaks(coords, intensities, num_peaks, min_distance, p_norm):
-    """Sort `coords` by descending `intensities`, enforce `min_distance`
-    spacing, and truncate to `num_peaks`.
-    """
-    if len(coords) == 0:
-        return coords
-    coords = coords[np.argsort(-intensities, stable=True)]
-
-    if min_distance > 1:
-        coords = _ensure_spacing(
-            coords, spacing=min_distance, p_norm=p_norm, max_out=num_peaks
-        )
-
-    if num_peaks is not None and len(coords) > num_peaks:
-        coords = coords[:num_peaks]
-
-    return coords
-
-
 def _get_high_intensity_peaks(image, mask, num_peaks, min_distance, p_norm):
     """
     Return the highest intensity peak coordinates.
     """
-    coords = np.nonzero(mask)
-    intensities = image[coords]
-    coords = np.transpose(coords)
-    return _filter_peaks(coords, intensities, num_peaks, min_distance, p_norm)
+    # get coordinates of peaks
+    coord = np.nonzero(mask)
+    intensities = image[coord]
+    # Highest peak first
+    idx_maxsort = np.argsort(-intensities, kind="stable")
+    coord = np.transpose(coord)[idx_maxsort]
+
+    if min_distance > 1:
+        coord = _ensure_spacing(
+            coord, spacing=min_distance, p_norm=p_norm, max_out=num_peaks
+        )
+
+    if num_peaks is not None and len(coord) > num_peaks:
+        coord = coord[:num_peaks]
+
+    return coord
 
 
 def _get_peak_mask(image, footprint, threshold, mask=None):
@@ -276,6 +269,9 @@ def peak_local_max(
     min_distance : float, optional
         The minimal allowed distance separating peaks. To find the
         maximum number of peaks, use `min_distance=1`. See also `p_norm`.
+        When `labels` is provided, `min_distance` is enforced within
+        each label region only; peaks in different label regions are
+        not suppressed by their spatial distance.
     threshold_abs : float, optional
         Minimum intensity of peaks. By default, the absolute threshold is
         the minimum intensity of the image.
@@ -432,11 +428,12 @@ def peak_local_max(
             coordinates = np.empty((0, image.ndim), dtype=int)
 
         if len(coordinates):
-            # Globally sort by descending intensity so the labels path
-            # returns peaks in the same order as the labels=None path.
+            # Globally sort by descending intensity. When `labels` is given,
+            # `min_distance` is enforced per label (above) but not across
+            # labels — `labels` define independent search regions.
             intensities = image[tuple(coordinates.T)]
-            coordinates = _filter_peaks(
-                coordinates, intensities, num_peaks, min_distance, p_norm
-            )
+            coordinates = coordinates[np.argsort(-intensities, stable=True)]
+            if num_peaks is not None and len(coordinates) > num_peaks:
+                coordinates = coordinates[:num_peaks]
 
     return coordinates

--- a/src/skimage/feature/peak.py
+++ b/src/skimage/feature/peak.py
@@ -152,7 +152,7 @@ def peak_local_max(
     Returns
     -------
     output : ndarray
-        The coordinates of the peaks.
+        The coordinates of the peaks, sorted by descending peak intensity.
 
     Notes
     -----

--- a/src/skimage/feature/peak.py
+++ b/src/skimage/feature/peak.py
@@ -111,6 +111,9 @@ def peak_local_max(
     min_distance : float, optional
         The minimal allowed distance separating peaks. To find the
         maximum number of peaks, use `min_distance=1`.
+        When `labels` is provided, `min_distance` is enforced within
+        each label region only; peaks in different label regions are
+        not suppressed by their spatial distance.
     threshold_abs : float or None, optional
         Minimum intensity of peaks. By default, the absolute threshold is
         the minimum intensity of the image.

--- a/tests/skimage/feature/test_corner.py
+++ b/tests/skimage/feature/test_corner.py
@@ -686,7 +686,7 @@ def test_corner_peaks_num_peaks_with_labels():
 
     corners = corner_peaks(img, num_peaks=2, labels=labels, num_peaks_per_label=1)
     expected = np.array([[4, 4], [2, 3]])
-    assert_array_equal(corners, expected)
+    assert_equal(corners, expected)
 
 
 def test_blank_image_nans():

--- a/tests/skimage/feature/test_corner.py
+++ b/tests/skimage/feature/test_corner.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_almost_equal, assert_array_equal, assert_equal
 
-from skimage import data, draw, img_as_float
+from skimage import data, draw, img_as_float, measure
 from _skimage2._shared._warnings import expected_warnings
 from _skimage2._shared.testing import run_in_parallel
 from _skimage2._shared.utils import _supported_float_type
@@ -671,6 +671,22 @@ def test_corner_peaks():
         response, exclude_border=False, min_distance=1, indices=False
     )
     assert np.sum(corners) == 5
+
+
+def test_corner_peaks_num_peaks_with_labels():
+    """`num_peaks` with `labels` should pick the globally brightest peaks,
+    not just the first ones in label order.
+    """
+    img = np.zeros((6, 6))
+    img[1, 1] = 1
+    img[2, 3] = 2
+    img[4, 4] = 3
+
+    labels = measure.label(img > 0)
+
+    corners = corner_peaks(img, num_peaks=2, labels=labels, num_peaks_per_label=1)
+    expected = np.array([[4, 4], [2, 3]])
+    assert_array_equal(corners, expected)
 
 
 def test_blank_image_nans():

--- a/tests/skimage2/feature/test_peaks.py
+++ b/tests/skimage2/feature/test_peaks.py
@@ -129,3 +129,36 @@ class TestPeakLocalMax:
     def test_num_peak_float_error(self):
         image = np.zeros((10, 10))
         peak_local_max(image, num_peaks=1.5)
+
+    @pytest.mark.parametrize("use_labels", [False, True])
+    @pytest.mark.parametrize("num_peaks", [None, 2, 100])
+    @pytest.mark.parametrize("num_peaks_per_label", [None, 1])
+    @pytest.mark.parametrize("min_distance", [1, 2])
+    def test_output_sorted_by_intensity(
+        self, use_labels, num_peaks, num_peaks_per_label, min_distance
+    ):
+        image = np.zeros((8, 8))
+        image[1, 1] = 1.0
+        image[2, 4] = 5.0
+        image[5, 2] = 3.0
+        image[6, 6] = 2.0
+        image[3, 7] = 4.0
+
+        if use_labels:
+            from skimage.measure import label
+
+            labels = label(image > 0)
+        else:
+            labels = None
+
+        peaks = peak_local_max(
+            image,
+            min_distance=min_distance,
+            num_peaks=num_peaks,
+            labels=labels,
+            num_peaks_per_label=num_peaks_per_label,
+        )
+        intensities = image[tuple(peaks.T)]
+        assert np.all(
+            intensities[:-1] >= intensities[1:]
+        ), f"output not intensity-sorted: {intensities.tolist()}"

--- a/tests/skimage2/feature/test_peaks.py
+++ b/tests/skimage2/feature/test_peaks.py
@@ -158,3 +158,22 @@ class TestPeakLocalMax:
         assert np.all(
             intensities[:-1] >= intensities[1:]
         ), f"output not intensity-sorted: {intensities.tolist()}"
+
+    def test_num_peaks_does_not_enforce_spacing_across_labels(self):
+        """`min_distance` is enforced within each label region only, never
+        across labels -- even when `num_peaks` truncates the output.
+
+        The two brightest peaks sit in different labels closer than
+        `min_distance`; both must be kept.
+        """
+        image = np.zeros((8, 8))
+        image[2, 2] = 5.0  # label A
+        image[2, 4] = 4.0  # label B, only 2 px from peak A (< min_distance)
+        image[6, 6] = 1.0  # label C, far away
+
+        labels = ndi.label(image > 0)[0]
+
+        peaks = peak_local_max(image, min_distance=3, num_peaks=2, labels=labels)
+
+        # Both close-but-differently-labeled peaks survive, in intensity order.
+        assert_equal(peaks, [[2, 2], [2, 4]])

--- a/tests/skimage2/feature/test_peaks.py
+++ b/tests/skimage2/feature/test_peaks.py
@@ -3,6 +3,7 @@ import pytest
 
 import numpy as np
 from numpy.testing import assert_equal
+from scipy import ndimage as ndi
 from scipy.spatial.distance import pdist, minkowski
 
 from _skimage2.feature._peaks import _ensure_spacing
@@ -144,12 +145,7 @@ class TestPeakLocalMax:
         image[6, 6] = 2.0
         image[3, 7] = 4.0
 
-        if use_labels:
-            from skimage.measure import label
-
-            labels = label(image > 0)
-        else:
-            labels = None
+        labels = ndi.label(image > 0)[0] if use_labels else None
 
         peaks = peak_local_max(
             image,


### PR DESCRIPTION
The merge request does the following:
* Sort the output coordinates of `peak_local_max` by descending peak intensity when providing labels
  * fixes `corner_peaks` to return the `num_peaks` in intensity order when using labels https://github.com/scikit-image/scikit-image/issues/8143
  * output of `peak_local_max` is now always sorted (has already been sorted before when running without labels)
* Do not enforce spacing over all labels when being above `num_peaks`
  * Can be regarded as a bug to not respect the labels for spacing
  * Updated doc strings for clarification
* Improve the performance of `_batched_ensure_spacing`

Relates to: https://github.com/scikit-image/scikit-image/pull/8167
Relates to: https://github.com/scikit-image/scikit-image/pull/8057

Fixes: https://github.com/scikit-image/scikit-image/issues/8143

### Release note (optional)

<!-- See https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes -->

```release-note
Sort the output coordinates of `peak_local_max` by descending peak intensity and respect labels when applying the spacing
```
