### PR TITLE
Drop `--maxfail=5` from local pytest config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,7 +195,6 @@ addopts = [
     "-ra",
     "--strict-config",
     "--strict-markers",
-    "--maxfail=5",
     "--showlocals",
     # Necessary for doctest collection with editable installations and
     # non-unique test module names (skimage/skimage2 duplicates those)


### PR DESCRIPTION
I've found that config to be more detrimental than useful, especially locally. And I remember, at least one case where some CI failures where hidden by this setting.

So I propose to drop it.

### Release note (optional)

<!-- See https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes -->

```release-note
...
```
