### PR TITLE
Fix _sigma_est_dwt to use proper median absolute deviation formula

### DIFF
--- a/src/skimage/restoration/_denoise.py
+++ b/src/skimage/restoration/_denoise.py
@@ -648,7 +648,8 @@ def _sigma_est_dwt(detail_coeffs, distribution='Gaussian'):
     if distribution.lower() == 'gaussian':
         # 75th quantile of the underlying, symmetric noise distribution
         denom = scipy.stats.norm.ppf(0.75)
-        sigma = np.median(np.abs(detail_coeffs)) / denom
+        # Median Absolute Deviation (MAD) as described in section 4.2 of [1].
+        sigma = np.median(np.abs(detail_coeffs - np.median(detail_coeffs))) / denom
     else:
         raise ValueError("Only Gaussian noise estimation is currently " "supported")
     return sigma

--- a/tests/skimage/restoration/test_denoise.py
+++ b/tests/skimage/restoration/test_denoise.py
@@ -970,6 +970,37 @@ def test_estimate_sigma_masked_image():
 
 
 @xfail_without_pywt
+def test_sigma_est_dwt_uses_mad():
+    """_sigma_est_dwt must use median absolute deviation, not median of abs.
+
+    Regression test for gh-8086: the formula was np.median(np.abs(d)) / 0.6745
+    instead of the correct MAD formula np.median(np.abs(d - np.median(d))) / 0.6745.
+
+    The two are equivalent only when median(d) ≈ 0.  This test uses coefficients
+    with a nonzero median to expose the difference.
+    """
+    from skimage.restoration._denoise import _sigma_est_dwt
+
+    rng = np.random.default_rng(0)
+    # Shift coefficients so their median is far from zero — exposing the bug.
+    detail_coeffs = rng.standard_normal(1000) + 5.0
+    sigma_est = _sigma_est_dwt(detail_coeffs, distribution='Gaussian')
+
+    # Ground-truth: standard deviation of the zero-mean component is 1.0;
+    # with the +5 offset the old formula would severely over-estimate sigma.
+    denom = 0.6745  # scipy.stats.norm.ppf(0.75)
+    sigma_correct = np.median(np.abs(detail_coeffs - np.median(detail_coeffs))) / denom
+    sigma_wrong = np.median(np.abs(detail_coeffs)) / denom
+
+    assert abs(sigma_est - sigma_correct) < abs(sigma_est - sigma_wrong), (
+        "sigma estimate should match MAD formula, not median-of-absolute formula"
+    )
+    assert abs(sigma_est - 1.0) < 0.1, (
+        f"estimated sigma {sigma_est:.3f} is too far from true sigma 1.0"
+    )
+
+
+@xfail_without_pywt
 @pytest.mark.parametrize('channel_axis', [0, 1, 2, -1])
 def test_estimate_sigma_color(channel_axis):
     rstate = np.random.RandomState(1591076970)


### PR DESCRIPTION
## Summary

Fixes #8086

`_sigma_est_dwt` in `restoration/_denoise.py` was computing:

```python
sigma = np.median(np.abs(detail_coeffs)) / denom
```

Section 4.2 of Donoho & Johnstone (1994) — the reference cited in the docstring — specifies the **median absolute deviation (MAD)**:

```python
sigma = np.median(np.abs(detail_coeffs - np.median(detail_coeffs))) / denom
```

The two are equivalent only when `median(detail_coeffs) ≈ 0`, which holds for typical noise-only wavelet coefficients at the finest scale. The MAD formula is more robust when a signal component is present (non-zero-centred coefficients).

## Changes

- `src/skimage/restoration/_denoise.py`: one-line fix in `_sigma_est_dwt`
- `tests/skimage/restoration/test_denoise.py`: `test_sigma_est_dwt_uses_mad` — uses offset coefficients (median ≠ 0) to expose the formula difference, and checks the estimate against the true sigma of 1.0

## Test plan

- [ ] New test `test_sigma_est_dwt_uses_mad` passes with the fix and would fail with the old formula
- [ ] All existing `test_estimate_sigma_*` tests pass (behaviour unchanged for zero-centred coefficients)