### PR TITLE
Fix lab2rgb/lab2xyz to not rescale integer LAB inputs

### DIFF
--- a/src/skimage/color/colorconv.py
+++ b/src/skimage/color/colorconv.py
@@ -1959,8 +1959,8 @@ def lch2lab(lch, *, channel_axis=-1):
 def _prepare_lab_array(arr, force_copy=True):
     """Ensure input for lab2lch and lch2lab is well-formed.
 
-    Input array must be in floating point and have at least 3 elements in the
-    last dimension. Returns a new array by default.
+    The input must have at least 3 elements in the last dimension and will be
+    returned as a floating-point array. Returns a new array by default.
 
     Integer inputs are cast to float without any rescaling.  LAB values have
     a well-defined numeric range (L*: 0–100, a*/b*: −128–127) and must not be

--- a/src/skimage/color/colorconv.py
+++ b/src/skimage/color/colorconv.py
@@ -1203,7 +1203,17 @@ def _lab2xyz(lab, illuminant, observer):
     n_invalid : int
         Number of invalid pixels in the Z channel after conversion.
     """
-    arr = _prepare_colorarray(lab, channel_axis=-1).copy()
+    lab = np.asanyarray(lab)
+    if lab.shape[-1] != 3:
+        msg = (
+            f'the input array must have size 3 along `channel_axis`, '
+            f'got {lab.shape}'
+        )
+        raise ValueError(msg)
+    # Cast to float without rescaling — LAB values (L: 0–100, a/b: −128–127)
+    # must not be normalised to [0, 1] the way img_as_float does for images.
+    float_dtype = _supported_float_type(lab.dtype)
+    arr = lab.astype(float_dtype, copy=True)
 
     L, a, b = arr[..., 0], arr[..., 1], arr[..., 2]
     y = (L + 16.0) / 116.0
@@ -1951,17 +1961,16 @@ def _prepare_lab_array(arr, force_copy=True):
 
     Input array must be in floating point and have at least 3 elements in the
     last dimension. Returns a new array by default.
+
+    Integer inputs are cast to float without any rescaling.  LAB values have
+    a well-defined numeric range (L*: 0–100, a*/b*: −128–127) and must not be
+    normalised to [0, 1] the way ``img_as_float`` does for image data.
     """
     arr = np.asarray(arr)
-    shape = arr.shape
-    if shape[-1] < 3:
+    if arr.shape[-1] < 3:
         raise ValueError('Input image has less than 3 channels.')
     float_dtype = _supported_float_type(arr.dtype)
-    if float_dtype == np.float32:
-        _func = dtype.img_as_float32
-    else:
-        _func = dtype.img_as_float64
-    return _func(arr, force_copy=force_copy)
+    return arr.astype(float_dtype, copy=force_copy)
 
 
 @channel_as_last_axis()

--- a/tests/skimage/color/test_colorconv.py
+++ b/tests/skimage/color/test_colorconv.py
@@ -546,6 +546,29 @@ class TestColorconv:
         assert lab2rgb(img).dtype == img.dtype
         assert lab2rgb(img32).dtype == img32.dtype
 
+    def test_lab2rgb_integer_input(self):
+        """Integer LAB values must not be rescaled before conversion.
+
+        Regression test for gh-6381: lab2rgb used img_as_float internally,
+        which rescaled int64 values like 75 to near-zero floats, yielding
+        [0., 0., 0.] instead of the correct sRGB result.
+        """
+        # Exact float result for reference
+        lab_float = np.array([[[75.0, 16.0, -12.0]]])
+        expected = lab2rgb(lab_float)
+        # Integer input must give the same result (within float64 rounding)
+        lab_int = np.array([[[75, 16, -12]]])  # dtype int64 on most platforms
+        result = lab2rgb(lab_int)
+        assert_array_almost_equal(result, expected, decimal=5)
+        # Ensure the result is not [0, 0, 0] (the pre-fix wrong answer)
+        assert not np.allclose(result, 0)
+
+    def test_lab2xyz_integer_input(self):
+        """Integer LAB arrays must be converted to float without rescaling."""
+        lab_float = np.array([[[50.0, 0.0, 0.0]]])
+        lab_int = np.array([[[50, 0, 0]]])
+        assert_array_almost_equal(lab2xyz(lab_int), lab2xyz(lab_float), decimal=5)
+
     # test matrices for xyz2luv and luv2xyz generated using
     # http://www.easyrgb.com/index.php?X=CALC
     # Note: easyrgb website displays xyz*100


### PR DESCRIPTION
## Summary

Fixes #6381

`lab2rgb([75, 16, -12])` returned `[0., 0., 0.]` instead of the correct `[0.80, 0.69, 0.81]`.

**Root cause:** `_lab2xyz` called `_prepare_colorarray`, which internally uses `img_as_float`. For integer dtypes, `img_as_float` rescales values to `[-1.0, 1.0]` — correct for image pixel data, but wrong for LAB values. An integer `75` (L* channel) became `~2e-18`, losing all information before the conversion.

**Fix:** Replace the `img_as_float` call in `_lab2xyz` with a plain `.astype(float_dtype)` cast. LAB channels (L*: 0–100, a*/b*: −128–127) have fixed numeric ranges and must not be rescaled. The same fix is applied to `_prepare_lab_array` (used by `lab2lch` / `lch2lab`) which had the identical problem.

This matches MATLAB's `lab2rgb` behaviour, which accepts integer LAB arrays without rescaling.

## Changes

- `src/skimage/color/colorconv.py`:
  - `_lab2xyz`: validate shape + cast to float without rescaling (replaces `_prepare_colorarray` call)
  - `_prepare_lab_array`: use `.astype()` instead of `img_as_float32/64`
- `tests/skimage/color/test_colorconv.py`:
  - `test_lab2rgb_integer_input`: round-trips `[75, 16, -12]` as int64 and asserts the result matches the float64 path
  - `test_lab2xyz_integer_input`: same check for `lab2xyz`

## Test plan

- [ ] `test_lab2rgb_integer_input` passes and would fail on the old code
- [ ] `test_lab2xyz_integer_input` passes and would fail on the old code
- [ ] All existing `test_lab2xyz`, `test_lab_rgb_roundtrip`, `test_lab2xyz_dtype`, `test_lab2rgb_dtype` pass unchanged