### PR TITLE
POC: Array API compatibility 

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+import json
 
 import click
 import spin
@@ -200,6 +201,14 @@ def _get_test_paths(changed_subpackages, doctest):
 
 
 @click.option(
+    '--array-api-backend', '-b', default=None, metavar='ARRAY_BACKEND',
+    multiple=True,
+    help=(
+        "Array API backend "
+        "('all', 'numpy', 'torch', 'cupy', 'array_api_strict', " "'jax.numpy')."
+    )
+)
+@click.option(
     "--installed",
     is_flag=True,
     default=False,
@@ -231,6 +240,7 @@ def test(
     test_modified=False,
     doctest=False,
     base_ref=None,
+    array_api_backend,
     **kwargs,
 ):
     pytest_args = kwargs.get('pytest_args', ())
@@ -272,6 +282,9 @@ def test(
     if doctest:
         if '--doctest-plus' not in pytest_args:
             pytest_args = ('--doctest-plus',) + pytest_args
+
+    if len(array_api_backend) != 0:
+        os.environ['SCIPY_ARRAY_API'] = json.dumps(list(array_api_backend))
 
     if installed:
         spin.util.run(['pytest'] + list(pytest_args))

--- a/src/_skimage2/_shared/filters.py
+++ b/src/_skimage2/_shared/filters.py
@@ -131,7 +131,7 @@ def gaussian(
             sigma.insert(channel_axis % image.ndim, 0)
     image = convert_to_float(image, preserve_range)
     float_dtype = _supported_float_type(image.dtype, xp=xp)
-    image = image.astype(float_dtype, copy=False)
+    image = xp.astype(image, float_dtype, copy=False)
     if (out is not None) and (not np.issubdtype(out.dtype, np.floating)):
         raise ValueError(f"dtype of `out` must be float; got {out.dtype!r}.")
     return ndi.gaussian_filter(

--- a/src/_skimage2/_shared/filters.py
+++ b/src/_skimage2/_shared/filters.py
@@ -14,6 +14,7 @@ from .utils import (
     _supported_float_type,
     convert_to_float,
 )
+from _skimage2.util._array_api import array_namespace
 
 
 def gaussian(
@@ -117,7 +118,9 @@ def gaussian(
     >>> filtered_img = ski.filters.gaussian(image, sigma=1, channel_axis=-1)
 
     """
-    if np.any(np.asarray(sigma) < 0.0):
+    xp = array_namespace(image)
+
+    if xp.any(xp.asarray(sigma) < 0.0):
         raise ValueError("Sigma values less than zero are not valid")
     if channel_axis is not None:
         # do not filter across channels
@@ -127,7 +130,7 @@ def gaussian(
             sigma = list(sigma)
             sigma.insert(channel_axis % image.ndim, 0)
     image = convert_to_float(image, preserve_range)
-    float_dtype = _supported_float_type(image.dtype)
+    float_dtype = _supported_float_type(image.dtype, xp=xp)
     image = image.astype(float_dtype, copy=False)
     if (out is not None) and (not np.issubdtype(out.dtype, np.floating)):
         raise ValueError(f"dtype of `out` must be float; got {out.dtype!r}.")

--- a/src/_skimage2/_shared/utils.py
+++ b/src/_skimage2/_shared/utils.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 import numpy as np
 
 from ._warnings import all_warnings, warn
+from ..util._array_api import is_numpy
 
 
 __all__ = [
@@ -1075,7 +1076,9 @@ new_float_type = {
 }
 
 
-def _supported_float_type(input_dtype, allow_complex=False):
+# XXX: xp=np is *temporary*; it is a bad idiom, and should be removed once
+# all call sites use an explicit xp argument
+def _supported_float_type(input_dtype, allow_complex=False, xp=np):
     """Return an appropriate floating-point dtype for a given dtype.
 
     float32, float64, complex64, complex128 are preserved.
@@ -1099,12 +1102,25 @@ def _supported_float_type(input_dtype, allow_complex=False):
         Floating-point dtype for the image.
     """
     if isinstance(input_dtype, tuple):
-        return np.result_type(*(_supported_float_type(d) for d in input_dtype))
-    input_dtype = np.dtype(input_dtype)
-    if not allow_complex and input_dtype.kind == 'c':
+        return xp.result_type(*(_supported_float_type(d, xp=xp) for d in input_dtype))
+    if is_numpy(xp):
+        input_dtype = np.dtype(input_dtype)
+    if not allow_complex and xp.isdtype(input_dtype, 'complex floating'):
         raise ValueError("complex valued input is not supported")
-    return new_float_type.get(input_dtype.char, np.float64)
 
+    # long and short dtypes: may or may not exist, depending on the array library
+    if getattr(xp, "float16", None) and input_dtype == xp.float16:
+        return xp.float32
+    if getattr(xp, "longdouble", None) and input_dtype == xp.longdouble:
+        return xp.float64
+    if getattr(xp, "clongdouble", None) and input_dtype == xp.clongdouble:
+        return xp.complex128
+
+    if input_dtype in (xp.float32, xp.float64, xp.complex64, xp.complex128):
+        return input_dtype
+
+    # nothing worked; default to float64
+    return xp.float64
 
 def identity(image, *args, **kwargs):
     """Returns the first argument unmodified."""

--- a/src/_skimage2/_shared/utils.py
+++ b/src/_skimage2/_shared/utils.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 import numpy as np
 
 from ._warnings import all_warnings, warn
-from ..util._array_api import is_numpy
+from ..util._array_api import is_numpy, array_namespace
 
 
 __all__ = [
@@ -976,13 +976,14 @@ def convert_to_float(image, preserve_range):
         Transformed version of the input.
 
     """
-    if image.dtype == np.float16:
-        return image.astype(np.float32)
+    xp = array_namespace(image)
+    if is_numpy(xp) and image.dtype == np.float16:
+        return xp.astype(image, xp.float32)
     if preserve_range:
         # Convert image to double only if it is not single or double
         # precision float
-        if image.dtype.char not in 'df':
-            image = image.astype(float)
+        if not xp.isdtype(image.dtype, "real floating"):
+            image = xp.astype(image, xp.float64)
     else:
         # Avoid circular import
         from skimage.util.dtype import img_as_float

--- a/src/_skimage2/metrics/_structural_similarity.py
+++ b/src/_skimage2/metrics/_structural_similarity.py
@@ -7,7 +7,7 @@ from _skimage2._shared import utils
 from _skimage2._shared._warnings import warn_external
 from _skimage2._shared.filters import gaussian
 from _skimage2._shared.utils import _supported_float_type, check_shape_equality
-from _skimage2.util._array_api import array_namespace
+from _skimage2.util._array_api import array_namespace, xp_size
 
 __all__ = ['structural_similarity']
 
@@ -258,7 +258,7 @@ def structural_similarity(
         grad = filter_func(A1 / D, **filter_args) * im1
         grad += filter_func(-S / B2, **filter_args) * im2
         grad += filter_func((ux * (A2 - A1) - uy * (B2 - B1) * S) / D, **filter_args)
-        grad *= 2 / im1.size
+        grad *= 2 / xp_size(im1)
 
         if full:
             return mssim, grad, S

--- a/src/_skimage2/metrics/_structural_similarity.py
+++ b/src/_skimage2/metrics/_structural_similarity.py
@@ -7,6 +7,7 @@ from _skimage2._shared import utils
 from _skimage2._shared._warnings import warn_external
 from _skimage2._shared.filters import gaussian
 from _skimage2._shared.utils import _supported_float_type, check_shape_equality
+from _skimage2.util._array_api import array_namespace
 
 __all__ = ['structural_similarity']
 
@@ -111,11 +112,13 @@ def structural_similarity(
     # TODO Undo inlined imports once available in _skimage2 namespace
     from skimage.util.arraycrop import crop
 
+    xp = array_namespace(im1, im2)
+
     if im1.dtype != im2.dtype:
         warn_external("Inputs have mismatched dtypes")
 
     check_shape_equality(im1, im2)
-    float_type = _supported_float_type(im1.dtype)
+    float_type = _supported_float_type(im1.dtype, xp=xp)
 
     if channel_axis is not None:
         # loop over channels
@@ -132,12 +135,12 @@ def structural_similarity(
             sigma=sigma,
         )
         nch = im1.shape[channel_axis]
-        mssim = np.empty(nch, dtype=float_type)
+        mssim = xp.empty(nch, dtype=float_type)
 
         if gradient:
-            G = np.empty(im1.shape, dtype=float_type)
+            G = xp.empty(im1.shape, dtype=float_type)
         if full:
-            S = np.empty(im1.shape, dtype=float_type)
+            S = xp.empty(im1.shape, dtype=float_type)
         channel_axis = channel_axis % im1.ndim
         _at = functools.partial(utils.slice_at_axis, axis=channel_axis)
         for ch in range(nch):
@@ -183,7 +186,7 @@ def structural_similarity(
     elif win_size is None:
         win_size = 7  # backwards compatibility
 
-    if np.any((np.asarray(im1.shape) - win_size) < 0):
+    if xp.any((xp.asarray(im1.shape) - win_size) < 0):
         raise ValueError(
             'win_size exceeds image extent. '
             'Either ensure that your images are '
@@ -208,8 +211,8 @@ def structural_similarity(
         filter_args = {'size': win_size}
 
     # ndimage filters need floating point data
-    im1 = im1.astype(float_type, copy=False)
-    im2 = im2.astype(float_type, copy=False)
+    im1 = xp.astype(im1, float_type, copy=False)
+    im2 = xp.astype(im2, float_type, copy=False)
 
     NP = win_size**ndim
 
@@ -248,7 +251,7 @@ def structural_similarity(
     pad = (win_size - 1) // 2
 
     # compute (weighted) mean of ssim. Use float64 for accuracy.
-    mssim = crop(S, pad).mean(dtype=np.float64)
+    mssim = xp.mean(crop(S, pad), dtype=xp.float64)
 
     if gradient:
         # The following is Eqs. 7-8 of Avanaki 2009.

--- a/src/_skimage2/util/_array_api.py
+++ b/src/_skimage2/util/_array_api.py
@@ -1,0 +1,22 @@
+import os
+
+from scipy._lib._array_api import (
+    xp_assert_close,
+    xp_assert_equal,
+    assert_array_almost_equal,
+    assert_almost_equal,
+
+    array_namespace,
+    xp_swapaxes,
+
+    default_xp,
+    _xp_copy_to_numpy,
+
+    is_torch,
+)
+
+
+# To enable array API and strict array-like input validation
+SCIPY_ARRAY_API: str | bool = os.environ.get("SCIPY_ARRAY_API", False)
+# To control the default device - for use in the test suite only
+SCIPY_DEVICE = os.environ.get("SCIPY_DEVICE", "cpu")

--- a/src/_skimage2/util/_array_api.py
+++ b/src/_skimage2/util/_array_api.py
@@ -8,6 +8,7 @@ from scipy._lib._array_api import (
 
     array_namespace,
     xp_swapaxes,
+    xp_size,
 
     default_xp,
     _xp_copy_to_numpy,

--- a/src/_skimage2/util/_array_api.py
+++ b/src/_skimage2/util/_array_api.py
@@ -14,6 +14,7 @@ from scipy._lib._array_api import (
 
     is_torch,
     is_numpy,
+    is_cupy,
 )
 
 

--- a/src/_skimage2/util/_array_api.py
+++ b/src/_skimage2/util/_array_api.py
@@ -13,6 +13,7 @@ from scipy._lib._array_api import (
     _xp_copy_to_numpy,
 
     is_torch,
+    is_numpy,
 )
 
 

--- a/src/_skimage2/util/meson.build
+++ b/src/_skimage2/util/meson.build
@@ -2,6 +2,7 @@ python_sources = [
   '__init__.py',
   '__init__.pyi',
   '_value_rescaling.py',
+  '_array_api.py',
 ]
 
 py3.install_sources(

--- a/src/skimage/util/arraycrop.py
+++ b/src/skimage/util/arraycrop.py
@@ -5,6 +5,7 @@ n-dimensional array.
 
 import numpy as np
 from numbers import Integral
+from _skimage2.util._array_api import array_namespace
 
 __all__ = ['crop']
 
@@ -38,7 +39,8 @@ def crop(ar, crop_width, copy=False, order='K'):
         The cropped array. If ``copy=False`` (default), this is a sliced
         view of the input array.
     """
-    ar = np.array(ar, copy=False)
+    xp = array_namespace(ar)
+    ar = xp.asarray(ar, copy=False)
 
     if isinstance(crop_width, Integral):
         crops = [[crop_width, crop_width]] * ar.ndim
@@ -66,7 +68,7 @@ def crop(ar, crop_width, copy=False, order='K'):
 
     slices = tuple(slice(a, ar.shape[i] - b) for i, (a, b) in enumerate(crops))
     if copy:
-        cropped = np.array(ar[slices], order=order, copy=True)
+        cropped = xp.asarray(ar[slices], order=order, copy=True)
     else:
         cropped = ar[slices]
     return cropped

--- a/src/skimage/util/dtype.py
+++ b/src/skimage/util/dtype.py
@@ -2,7 +2,7 @@ import warnings
 from warnings import warn
 
 import numpy as np
-
+from _skimage2.util._array_api import array_namespace, is_numpy, is_cupy
 
 __all__ = [
     'img_as_float32',
@@ -207,6 +207,20 @@ def _scale(a, n, m, copy=True):
 
 
 def _convert(image, dtype, force_copy=False, uniform=False):
+    # Here we (ab)use the fact that CuPy dtypes are in fact numpy dtypes.
+    # _convert_internal only deals with numpy dtypes and numpy or cupy arrays.
+    #
+    # pytorch etc CPU tensors go through numpy; can in principle make
+    # pytorch GPU tensors go through cupy (not done here)
+    xp = array_namespace(image)
+    xp_internal = xp if (is_numpy(xp) or is_cupy(xp)) else np
+
+    image = xp_internal.asarray(image)
+    result = _convert_internal(image, dtype, force_copy, uniform)
+    return xp.asarray(result)
+
+
+def _convert_internal(image, dtype, force_copy=False, uniform=False):
     """
     Convert an image to the requested data-type.
 
@@ -256,7 +270,6 @@ def _convert(image, dtype, force_copy=False, uniform=False):
            pp 47-57. Morgan Kaufmann, 1998.
 
     """
-    image = np.asarray(image)
     dtypeobj_in = image.dtype
     if dtype is np.floating:
         dtypeobj_out = np.dtype('float64')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,13 +3,20 @@ from pathlib import Path
 import pytest
 from time import perf_counter
 from datetime import timedelta
+import json
 import os
 import sys
 import sysconfig
+from typing import Literal
 from pytest_pretty import CustomTerminalReporter
 
 from _pytest.terminal import TerminalReporter
 from _pytest.pathlib import bestrelpath
+
+import numpy as np
+from _skimage2.util._array_api import (
+    SCIPY_ARRAY_API, SCIPY_DEVICE, array_namespace, default_xp
+)
 
 
 FREE_THREADED_BUILD = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
@@ -65,6 +72,16 @@ def pytest_configure(config: pytest.Config) -> None:
     config.pluginmanager.unregister(standard_reporter)
     config.pluginmanager.register(custom_reporter, 'terminalreporter')
 
+    config.addinivalue_line("markers",
+        "array_api_backends: test iterates on all array API backends")
+    config.addinivalue_line("markers",
+        ("skip_xp_backends(backends, reason=None, np_only=False, cpu_only=False, " +
+         "eager_only=False, exceptions=None): mark the desired skip configuration " +
+         "for the `skip_xp_backends` fixture"))
+    config.addinivalue_line("markers",
+        ("xfail_xp_backends(backends, reason=None, np_only=False, cpu_only=False, " +
+         "eager_only=False, exceptions=None): mark the desired xfail configuration " +
+         "for the `xfail_xp_backends` fixture"))
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
     if FREE_THREADED_BUILD and not GIL_ENABLED_AT_START and sys._is_gil_enabled():
@@ -78,3 +95,295 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
         tr.line("Please ensure all new C and C++ extensions declare support")
         tr.line("for running without the GIL.")
         pytest.exit("GIL re-enabled during tests", returncode=1)
+
+
+# Array API backend handling
+# XXX parroted from SciPy; deduplicate?
+xp_known_backends = {'numpy', 'array_api_strict', 'torch', 'cupy', 'jax.numpy',
+                     'dask.array'}
+xp_available_backends = [
+    pytest.param(np, id='numpy', marks=pytest.mark.array_api_backends)
+]
+xp_skip_cpu_only_backends = set()
+xp_skip_eager_only_backends = set()
+
+if SCIPY_ARRAY_API:
+    # fill the dict of backends with available libraries
+    try:
+        import array_api_strict
+        xp_available_backends.append(
+            pytest.param(array_api_strict, id='array_api_strict',
+                         marks=pytest.mark.array_api_backends))
+        if array_api_strict.__version__ < '2.3':   # XXX: packaging.version
+            raise ImportError("array-api-strict must be >= version 2.3")
+        array_api_strict.set_array_api_strict_flags(
+            api_version='2025.12'
+        )
+    except ImportError:
+        pass
+
+    try:
+        import torch  # type: ignore[import-not-found]
+        xp_available_backends.append(
+            pytest.param(torch, id='torch',
+            marks=pytest.mark.array_api_backends))
+        torch.set_default_device(SCIPY_DEVICE)
+        if SCIPY_DEVICE != "cpu":
+            xp_skip_cpu_only_backends.add('torch')
+
+        # default to float64 unless explicitly requested
+        default = os.getenv('SCIPY_DEFAULT_DTYPE', default='float64')
+        if default == 'float64':
+            torch.set_default_dtype(torch.float64)
+        elif default != "float32":
+            raise ValueError(
+                "SCIPY_DEFAULT_DTYPE env var, if set, can only be either 'float64' "
+               f"or 'float32'. Got '{default}' instead."
+            )
+    except ImportError:
+        pass
+
+    try:
+        import cupy  # type: ignore[import-not-found]
+        # Note: cupy disregards SCIPY_DEVICE and always runs on cuda.
+        # It will fail to import if you don't have CUDA hardware and drivers.
+        xp_available_backends.append(
+            pytest.param(cupy, id='cupy',
+            marks=pytest.mark.array_api_backends))
+        xp_skip_cpu_only_backends.add('cupy')
+
+        # this is annoying in CuPy 13.x
+        warnings.filterwarnings(
+            'ignore', 'cupyx.jit.rawkernel is experimental', category=FutureWarning
+        )
+        from cupyx.scipy import signal
+        del signal
+    except ImportError:
+        pass
+
+    try:
+        import jax.numpy  # type: ignore[import-not-found]
+        
+        xp_available_backends.append(
+            pytest.param(jax.numpy, id='jax.numpy',
+            marks=[pytest.mark.array_api_backends,
+                   # Uses xpx.testing.patch_lazy_xp_functions to monkey-patch module
+                   pytest.mark.thread_unsafe]))
+
+        jax.config.update("jax_enable_x64", True)
+        # Make sure JAX won't default to less accurate TensorFloat32 precision
+        # in matmuls with float32 inputs on GPUs that support this floating
+        # point format.
+        jax.config.update("jax_default_matmul_precision", "float32")
+        jax.config.update("jax_default_device", jax.devices(SCIPY_DEVICE)[0])
+        if SCIPY_DEVICE != "cpu":
+            xp_skip_cpu_only_backends.add('jax.numpy')
+        # JAX can be eager or lazy (when wrapped in jax.jit). However it is
+        # recommended by upstream devs to assume it's always lazy.
+        xp_skip_eager_only_backends.add('jax.numpy')
+    except ImportError:
+        pass
+
+
+    xp_available_backend_ids = {p.id for p in xp_available_backends}
+    assert not xp_available_backend_ids - xp_known_backends
+
+    # by default, use all available backends
+    if (
+        isinstance(SCIPY_ARRAY_API, str)
+        and SCIPY_ARRAY_API.lower() not in ("1", "true", "all")
+    ):
+        SCIPY_ARRAY_API_ = set(json.loads(SCIPY_ARRAY_API))
+        if SCIPY_ARRAY_API_ != {'all'}:
+            if SCIPY_ARRAY_API_ - xp_available_backend_ids:
+                msg = ("'--array-api-backend' must be in "
+                       f"{xp_available_backend_ids}; got {SCIPY_ARRAY_API_}")
+                raise ValueError(msg)
+            # Only select a subset of backends
+            xp_available_backends = [
+                param for param in xp_available_backends
+                if param.id in SCIPY_ARRAY_API_
+            ]
+
+@pytest.fixture(params=xp_available_backends)
+def xp(request):
+    """Run the test that uses this fixture on each available array API library.
+
+    You can select all and only the tests that use the `xp` fixture by
+    passing `-m array_api_backends` to pytest.
+
+    You can select where individual tests run through the `@skip_xp_backends`,
+    `@xfail_xp_backends`, and `@skip_xp_invalid_arg` pytest markers.
+
+    Please read: https://docs.scipy.org/doc/scipy/dev/api-dev/array_api.html#adding-tests
+    """
+    # Read all @pytest.marks.skip_xp_backends markers that decorate to the test,
+    # if any, and raise pytest.skip() if the current xp is in the list.
+    skip_or_xfail_xp_backends(request, "skip")
+    # Read all @pytest.marks.xfail_xp_backends markers that decorate the test,
+    # if any, and raise pytest.xfail() if the current xp is in the list.
+    skip_or_xfail_xp_backends(request, "xfail")
+
+    # Check if ``uses_xp_capabilities`` mark is present.
+    # ``scipy._lib._array_api.make_xp_pytest_marks``, which draws from
+    # ``xp_capabilities``, will set ``pytest.mark.uses_xp_capabilities(True)``.
+    # Tests which are unconverted or which are for private functions without
+    # ``xp_capabilities`` entries should have
+    # ``pytest.mark.uses_xp_capabilities(False)`` explicitly set.
+##    if request.node.get_closest_marker("uses_xp_capabilities") is None:
+##        warnings.warn(
+##            "test uses `xp` fixture without drawing from `xp_capabilities` "
+##            " but is not explicitly marked with"
+##            " ``pytest.mark.uses_xp_capabilities(False)``",
+##            stacklevel=0,
+##        )
+
+    xp = request.param
+    # Potentially wrap namespace with array_api_compat
+    xp = array_namespace(xp.empty(0))
+
+    if SCIPY_ARRAY_API:
+        # If xp==jax.numpy, wrap tested functions in jax.jit
+        # If xp==dask.array, wrap tested functions to test that graph is not computed
+##        with patch_lazy_xp_functions(request=request, xp=request.param):
+            # Throughout all calls to assert_almost_equal, assert_array_almost_equal,
+            # and xp_assert_* functions, test that the array namespace is xp in both
+            # the expected and actual arrays. This is to detect the case where both
+            # arrays are erroneously just plain numpy while xp is something else.
+            with default_xp(xp):
+                yield xp
+    else:
+        yield xp
+
+
+skip_xp_invalid_arg = pytest.mark.skipif(SCIPY_ARRAY_API,
+    reason = ('Test involves masked arrays, object arrays, or other types '
+              'that are not valid input when `SCIPY_ARRAY_API` is used.'))
+
+
+def _backends_kwargs_from_request(request, skip_or_xfail):
+    """A helper for {skip,xfail}_xp_backends.
+
+    Return dict of {backend to skip/xfail: top reason to skip/xfail it}
+    """
+    markers = list(request.node.iter_markers(f'{skip_or_xfail}_xp_backends'))
+    reasons = {backend: [] for backend in xp_known_backends}
+
+    for marker in markers:
+        invalid_kwargs = set(marker.kwargs) - {
+            "cpu_only", "np_only", "eager_only", "reason", "exceptions"}
+        if invalid_kwargs:
+            raise TypeError(f"Invalid kwargs: {invalid_kwargs}")
+
+        exceptions = set(marker.kwargs.get('exceptions', []))
+        invalid_exceptions = exceptions - xp_known_backends
+        if (invalid_exceptions := list(exceptions - xp_known_backends)):
+            raise ValueError(f"Unknown backend(s): {invalid_exceptions}; "
+                             f"must be a subset of {list(xp_known_backends)}")
+
+        if marker.kwargs.get('np_only', False):
+            reason = marker.kwargs.get("reason") or "do not run with non-NumPy backends"
+            for backend, backend_reasons in reasons.items():
+                if backend != 'numpy' and backend not in exceptions:
+                    backend_reasons.append(reason)
+
+        elif marker.kwargs.get('cpu_only', False):
+            reason = marker.kwargs.get("reason") or (
+                "no array-agnostic implementation or delegation available "
+                "for this backend and device")
+            for backend in xp_skip_cpu_only_backends - exceptions:
+                reasons[backend].append(reason)
+
+        elif marker.kwargs.get('eager_only', False):
+            reason = marker.kwargs.get("reason") or (
+                "eager checks not executed on lazy backends")
+            for backend in xp_skip_eager_only_backends - exceptions:
+                reasons[backend].append(reason)
+
+        # add backends, if any
+        if len(marker.args) == 1:
+            backend = marker.args[0]
+            if backend not in xp_known_backends:
+                raise ValueError(f"Unknown backend: {backend}; "
+                                 f"must be one of {list(xp_known_backends)}")
+            reason = marker.kwargs.get("reason") or (
+                f"do not run with array API backend: {backend}")
+            # reason overrides the ones from cpu_only, np_only, and eager_only.
+            # This is regardless of order of appearence of the markers.
+            reasons[backend].insert(0, reason)
+
+            for kwarg in ("cpu_only", "np_only", "eager_only", "exceptions"):
+                if kwarg in marker.kwargs:
+                    raise ValueError(f"{kwarg} is mutually exclusive with {backend}")
+
+        elif len(marker.args) > 1:
+            raise ValueError(
+                f"Please specify only one backend per marker: {marker.args}"
+            )
+
+    return {backend: backend_reasons[0]
+            for backend, backend_reasons in reasons.items()
+            if backend_reasons}
+
+
+def skip_or_xfail_xp_backends(request: pytest.FixtureRequest,
+                              skip_or_xfail: Literal['skip', 'xfail']) -> None:
+    """
+    Helper of the `xp` fixture.
+    Skip or xfail based on the ``skip_xp_backends`` or ``xfail_xp_backends`` markers.
+
+    See the "Support for the array API standard" docs page for usage examples.
+
+    Usage
+    -----
+    ::
+        skip_xp_backends = pytest.mark.skip_xp_backends
+        xfail_xp_backends = pytest.mark.xfail_xp_backends
+        ...
+
+        @skip_xp_backends(backend, *, reason=None)
+        @skip_xp_backends(*, cpu_only=True, exceptions=(), reason=None)
+        @skip_xp_backends(*, eager_only=True, exceptions=(), reason=None)
+        @skip_xp_backends(*, np_only=True, exceptions=(), reason=None)
+
+        @xfail_xp_backends(backend, *, reason=None)
+        @xfail_xp_backends(*, cpu_only=True, exceptions=(), reason=None)
+        @xfail_xp_backends(*, eager_only=True, exceptions=(), reason=None)
+        @xfail_xp_backends(*, np_only=True, exceptions=(), reason=None)
+
+    Parameters
+    ----------
+    backend : str, optional
+        Backend to skip/xfail, e.g. ``"torch"``.
+        Mutually exclusive with ``cpu_only``, ``eager_only``, and ``np_only``.
+    cpu_only : bool, optional
+        When ``True``, the test is skipped/xfailed on non-CPU devices,
+        minus exceptions. Mutually exclusive with ``backend``.
+    eager_only : bool, optional
+        When ``True``, the test is skipped/xfailed for lazy backends, e.g. those
+        with major caveats when invoking ``__array__``, ``__bool__``, ``__float__``,
+        or ``__complex__``, minus exceptions. Mutually exclusive with ``backend``.
+    np_only : bool, optional
+        When ``True``, the test is skipped/xfailed for all backends other
+        than the default NumPy backend and the exceptions.
+        Mutually exclusive with ``backend``. Implies ``cpu_only`` and ``eager_only``.
+    reason : str, optional
+        A reason for the skip/xfail. If omitted, a default reason is used.
+    exceptions : list[str], optional
+        A list of exceptions for use with ``cpu_only``, ``eager_only``, or ``np_only``.
+        This should be provided when delegation is implemented for some,
+        but not all, non-CPU/non-NumPy backends.
+    """
+    if f"{skip_or_xfail}_xp_backends" not in request.keywords:
+        return
+
+    skip_xfail_reasons = _backends_kwargs_from_request(
+        request, skip_or_xfail=skip_or_xfail
+    )
+    xp = request.param
+    if xp.__name__ in skip_xfail_reasons:
+        reason = skip_xfail_reasons[xp.__name__]
+        assert reason  # Default reason applied above
+        skip_or_xfail = getattr(pytest, skip_or_xfail)
+        skip_or_xfail(reason=reason)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import json
 import os
 import sys
 import sysconfig
+import warnings
 from typing import Literal
 from pytest_pretty import CustomTerminalReporter
 

--- a/tests/skimage2/metrics/test_structural_similarity.py
+++ b/tests/skimage2/metrics/test_structural_similarity.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from numpy.testing import assert_equal, assert_almost_equal
+from _skimage2.util._array_api import xp_assert_equal, assert_almost_equal
 
 from _skimage2.metrics import structural_similarity
 from _skimage2._shared.utils import _supported_float_type
@@ -22,7 +22,7 @@ def test_structural_similarity_patch_range():
     Y = (np.random.rand(N, N) * 255).astype(np.uint8)
 
     assert structural_similarity(X, Y, data_range=255, win_size=N) < 0.1
-    assert_equal(structural_similarity(X, X, data_range=255, win_size=N), 1)
+    xp_assert_equal(structural_similarity(X, X, data_range=255, win_size=N), 1.0)
 
 
 def test_structural_similarity_image():
@@ -31,7 +31,7 @@ def test_structural_similarity_image():
     Y = (np.random.rand(N, N) * 255).astype(np.uint8)
 
     S0 = structural_similarity(X, X, data_range=255, win_size=3)
-    assert_equal(S0, 1)
+    xp_assert_equal(S0, 1.0)
 
     S1 = structural_similarity(X, Y, data_range=255, win_size=3)
     assert S1 < 0.3
@@ -40,12 +40,12 @@ def test_structural_similarity_image():
     assert S2 < 0.3
 
     mssim0, S3 = structural_similarity(X, Y, data_range=255, full=True)
-    assert_equal(S3.shape, X.shape)
+    assert S3.shape == X.shape
     mssim = structural_similarity(X, Y, data_range=255)
-    assert_equal(mssim0, mssim)
+    xp_assert_equal(mssim0, mssim)
 
     # structural_similarity of image with itself should be 1.0
-    assert_equal(structural_similarity(X, X, data_range=255), 1.0)
+    xp_assert_equal(structural_similarity(X, X, data_range=255), 1.0)
 
 
 # FIXME: Because we are forcing a random seed state, it is probably good to test
@@ -127,13 +127,13 @@ def test_structural_similarity_multichannel(channel_axis):
     m, S3 = structural_similarity(
         Xc, Yc, data_range=data_range, channel_axis=channel_axis, full=True
     )
-    assert_equal(S3.shape, Xc.shape)
+    assert S3.shape == Xc.shape
 
     # gradient case
     m, grad = structural_similarity(
         Xc, Yc, data_range=data_range, channel_axis=channel_axis, gradient=True
     )
-    assert_equal(grad.shape, Xc.shape)
+    assert grad.shape == Xc.shape
 
     # full and gradient case
     m, grad, S3 = structural_similarity(
@@ -144,8 +144,8 @@ def test_structural_similarity_multichannel(channel_axis):
         full=True,
         gradient=True,
     )
-    assert_equal(grad.shape, Xc.shape)
-    assert_equal(S3.shape, Xc.shape)
+    assert grad.shape == Xc.shape
+    assert S3.shape == Xc.shape
 
     # fail if win_size exceeds any non-channel dimension
     with pytest.raises(ValueError):
@@ -184,7 +184,7 @@ def test_structural_similarity_multichannel_chelsea():
     assert_almost_equal(mssim, np.mean(mssim_sep))
 
     # structural_similarity of image with itself should be 1.0
-    assert_equal(structural_similarity(Xc, Xc, data_range=255, channel_axis=-1), 1.0)
+    xp_assert_equal(structural_similarity(Xc, Xc, data_range=255, channel_axis=-1), 1.0)
 
 
 @pytest.mark.parametrize('gaussian_weights', [True, False])
@@ -277,8 +277,8 @@ def test_structural_similarity_small_image(dtype):
     X = np.zeros((5, 5), dtype=dtype)
     # structural_similarity can be computed for small images if win_size is
     # a) odd and b) less than or equal to the images' smaller side
-    assert_equal(structural_similarity(X, X, win_size=3, data_range=1.0), 1.0)
-    assert_equal(structural_similarity(X, X, win_size=5, data_range=1.0), 1.0)
+    xp_assert_equal(structural_similarity(X, X, win_size=3, data_range=1.0), 1.0)
+    xp_assert_equal(structural_similarity(X, X, win_size=5, data_range=1.0), 1.0)
     # structural_similarity errors for small images if user doesn't specify
     # win_size
     with pytest.raises(ValueError):

--- a/tests/skimage2/metrics/test_structural_similarity.py
+++ b/tests/skimage2/metrics/test_structural_similarity.py
@@ -1,7 +1,7 @@
 import math
 import numpy as np
 import pytest
-from _skimage2.util._array_api import xp_assert_equal, assert_almost_equal
+from _skimage2.util._array_api import xp_assert_equal, xp_assert_close, assert_almost_equal
 
 from _skimage2.metrics import structural_similarity
 from _skimage2._shared.utils import _supported_float_type
@@ -26,7 +26,11 @@ def test_structural_similarity_patch_range(xp):
     Y = xp.asarray(Y)
 
     assert structural_similarity(X, Y, data_range=255, win_size=N) < 0.1
-    assert structural_similarity(X, X, data_range=255, win_size=N) == 1.0
+    assert math.isclose(
+       structural_similarity(X, X, data_range=255, win_size=N),
+       1.0,
+       abs_tol=1e-15
+    )
 
 
 def test_structural_similarity_image(xp):
@@ -277,7 +281,11 @@ def test_mssim_vs_legacy(dtype, xp):
         xp.asarray(cam_noisy.astype(dtype)),
         data_range=255
     )
-    assert_almost_equal(xp.asarray(mssim), xp.asarray(mssim_skimage_0pt17))
+    xp_assert_close(
+        xp.asarray(mssim),
+        xp.asarray(mssim_skimage_0pt17),
+        atol=1e-5
+    )
 
 
 def test_ssim_warns_about_data_range():

--- a/tests/skimage2/metrics/test_structural_similarity.py
+++ b/tests/skimage2/metrics/test_structural_similarity.py
@@ -25,7 +25,7 @@ def test_structural_similarity_patch_range(xp):
     Y = xp.asarray(Y)
 
     assert structural_similarity(X, Y, data_range=255, win_size=N) < 0.1
-    xp_assert_equal(structural_similarity(X, X, data_range=255, win_size=N), 1.0)
+    assert structural_similarity(X, X, data_range=255, win_size=N) == 1.0
 
 
 def test_structural_similarity_image(xp):
@@ -37,7 +37,7 @@ def test_structural_similarity_image(xp):
     Y = xp.asarray(Y)
 
     S0 = structural_similarity(X, X, data_range=255, win_size=3)
-    xp_assert_equal(S0, 1.0)
+    assert S0 == 1.0
 
     S1 = structural_similarity(X, Y, data_range=255, win_size=3)
     assert S1 < 0.3
@@ -48,10 +48,10 @@ def test_structural_similarity_image(xp):
     mssim0, S3 = structural_similarity(X, Y, data_range=255, full=True)
     assert S3.shape == X.shape
     mssim = structural_similarity(X, Y, data_range=255)
-    xp_assert_equal(mssim0, mssim)
+    assert mssim0 == mssim
 
     # structural_similarity of image with itself should be 1.0
-    xp_assert_equal(structural_similarity(X, X, data_range=255), 1.0)
+    assert structural_similarity(X, X, data_range=255) == 1.0
 
 
 # FIXME: Because we are forcing a random seed state, it is probably good to test

--- a/tests/skimage2/metrics/test_structural_similarity.py
+++ b/tests/skimage2/metrics/test_structural_similarity.py
@@ -16,19 +16,25 @@ cam_noisy = cam_noisy.astype(cam.dtype)
 np.random.seed(1234)
 
 
-def test_structural_similarity_patch_range():
+def test_structural_similarity_patch_range(xp):
     N = 51
     X = (np.random.rand(N, N) * 255).astype(np.uint8)
     Y = (np.random.rand(N, N) * 255).astype(np.uint8)
+
+    X = xp.asarray(X)
+    Y = xp.asarray(Y)
 
     assert structural_similarity(X, Y, data_range=255, win_size=N) < 0.1
     xp_assert_equal(structural_similarity(X, X, data_range=255, win_size=N), 1.0)
 
 
-def test_structural_similarity_image():
+def test_structural_similarity_image(xp):
     N = 100
     X = (np.random.rand(N, N) * 255).astype(np.uint8)
     Y = (np.random.rand(N, N) * 255).astype(np.uint8)
+
+    X = xp.asarray(X)
+    Y = xp.asarray(Y)
 
     S0 = structural_similarity(X, X, data_range=255, win_size=3)
     xp_assert_equal(S0, 1.0)
@@ -52,7 +58,7 @@ def test_structural_similarity_image():
 #        against a few seeds in case on seed gives a particularly bad example
 @pytest.mark.parametrize('seed', [1, 2, 3, 5, 8, 13])
 @pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
-def test_structural_similarity_grad(seed, dtype):
+def test_structural_similarity_grad(seed, dtype, xp):
     N = 60
     # FIXME: This test is known to randomly fail on some systems (Mac OS X 10.6)
     #        And when testing tests in parallel. Therefore, we choose a few
@@ -63,6 +69,9 @@ def test_structural_similarity_grad(seed, dtype):
     rng = np.random.default_rng(seed)
     X = rng.random((N, N)).astype(dtype, copy=False) * 255
     Y = rng.random((N, N)).astype(dtype, copy=False) * 255
+
+    X = xp.asarray(X)
+    Y = xp.asarray(Y)
 
     f = structural_similarity(X, Y, data_range=255)
     g = structural_similarity(X, Y, data_range=255, gradient=True)
@@ -81,42 +90,50 @@ def test_structural_similarity_grad(seed, dtype):
 
 
 @pytest.mark.parametrize(
-    'dtype', [np.uint8, np.int32, np.float16, np.float32, np.float64]
+    'dtype_str', ['uint8', 'int32', 'float16', 'float32', 'float64']
 )
-def test_structural_similarity_dtype(dtype):
+def test_structural_similarity_dtype(dtype_str, xp):
     N = 30
     X = np.random.rand(N, N)
     Y = np.random.rand(N, N)
-    if np.dtype(dtype).kind in 'iub':
+
+    X = xp.asarray(X)
+    Y = xp.asarray(Y)
+    dtype = getattr(xp, dtype_str)
+
+    if xp.isdtype(dtype, ('integral', 'bool')):
+#    if np.dtype(dtype).kind in 'iub':
         data_range = 255.0
-        X = (X * 255).astype(dtype)
-        Y = (Y * 255).astype(dtype)
+        X = xp.astype(X * 255, dtype)
+        Y = xp.astype(Y * 255, dtype)
     else:
         data_range = 1.0
-        X = X.astype(dtype, copy=False)
-        Y = Y.astype(dtype, copy=False)
+        X = xp.astype(X, dtype, copy=False)
+        Y = xp.astype(Y, dtype, copy=False)
 
     S1 = structural_similarity(X, Y, data_range=data_range)
-    assert S1.dtype == np.float64
+    assert S1.dtype == xp.float64
 
     assert S1 < 0.1
 
 
 @pytest.mark.parametrize('channel_axis', [0, 1, 2, -1])
-def test_structural_similarity_multichannel(channel_axis):
+def test_structural_similarity_multichannel(channel_axis, xp):
     N = 100
     X = (np.random.rand(N, N) * 255).astype(np.uint8)
     Y = (np.random.rand(N, N) * 255).astype(np.uint8)
-    data_range = np.iinfo(np.uint8).max
+
+    X, Y = map(xp.asarray, (X, Y))
+    data_range = xp.iinfo(xp.uint8).max
 
     S1 = structural_similarity(X, Y, data_range=data_range, win_size=3)
 
     # replicate across three channels.  should get identical value
-    Xc = np.tile(X[..., np.newaxis], (1, 1, 3))
-    Yc = np.tile(Y[..., np.newaxis], (1, 1, 3))
+    Xc = xp.tile(X[..., xp.newaxis], (1, 1, 3))
+    Yc = xp.tile(Y[..., xp.newaxis], (1, 1, 3))
 
     # move channels from last position to specified channel_axis
-    Xc, Yc = (np.moveaxis(_arr, -1, channel_axis) for _arr in (Xc, Yc))
+    Xc, Yc = (xp.moveaxis(_arr, -1, channel_axis) for _arr in (Xc, Yc))
 
     S2 = structural_similarity(
         Xc, Yc, data_range=data_range, channel_axis=channel_axis, win_size=3
@@ -156,24 +173,26 @@ def test_structural_similarity_multichannel(channel_axis):
 
 @pytest.mark.parametrize('dtype', [np.uint8, np.float32, np.float64])
 @pytest.mark.parametrize('ndim', [1, 2, 3, 4])
-def test_structural_similarity_nD(dtype, ndim):
+def test_structural_similarity_nD(dtype, ndim, xp):
     # test 1D through 4D on small random arrays
     rng = np.random.default_rng(20260429)
     shape = (24 // ndim,) * ndim
     X = (rng.random(shape) * 255).astype(dtype)
     Y = (rng.random(shape) * 255).astype(dtype)
 
+    X, Y = map(xp.asarray, (X, Y))
+
     mssim = structural_similarity(X, Y, win_size=3, data_range=255.0)
-    assert mssim.dtype == np.float64
+    assert mssim.dtype == xp.float64
     assert mssim < 0.05
 
 
-def test_structural_similarity_multichannel_chelsea():
+def test_structural_similarity_multichannel_chelsea(xp):
     # color image example
     Xc = data.chelsea()
     sigma = 15.0
-    Yc = np.clip(Xc + sigma * np.random.randn(*Xc.shape), 0, 255)
-    Yc = Yc.astype(Xc.dtype)
+    Yc = xp.clip(xp.asarray(Xc + sigma * np.random.randn(*Xc.shape)), 0, 255)
+    Yc = xp.astype(Yc, Xc.dtype)
 
     # multichannel result should be mean of the individual channel results
     mssim = structural_similarity(Xc, Yc, data_range=255, channel_axis=-1)
@@ -188,16 +207,16 @@ def test_structural_similarity_multichannel_chelsea():
 
 
 @pytest.mark.parametrize('gaussian_weights', [True, False])
-def test_structural_similarity_dtype_insensitivity(gaussian_weights):
+def test_structural_similarity_dtype_insensitivity(gaussian_weights, xp):
     # Result of `structural_similarity` should be insensitive to the input dtype
-    image_int = np.arange(100, dtype=np.int64)
+    image_int = xp.arange(100, dtype=xp.int64)
     mssim_int = structural_similarity(
         image_int[1:],
         image_int[:-1],
         data_range=image_int.max(),
         gaussian_weights=gaussian_weights,
     )
-    image_float = image_int.astype(np.float64)
+    image_float = xp.astype(image_int, xp.float64)
     mssim_float = structural_similarity(
         image_float[1:],
         image_float[:-1],
@@ -208,7 +227,7 @@ def test_structural_similarity_dtype_insensitivity(gaussian_weights):
     assert mssim_float < 1.0
 
 
-def test_gaussian_structural_similarity_vs_IPOL():
+def test_gaussian_structural_similarity_vs_IPOL(xp):
     """Tests vs. imdiff result from the following IPOL article and code:
     https://www.ipol.im/pub/art/2011/g_lmii/.
 
@@ -230,9 +249,9 @@ def test_gaussian_structural_similarity_vs_IPOL():
     assert cam.dtype == np.uint8
     assert cam_noisy.dtype == np.uint8
     mssim = structural_similarity(
-        cam,
-        cam_noisy,
-        data_range=np.iinfo(np.uint8).max,
+        xp.asarray(cam),
+        xp.asarray(cam_noisy),
+        data_range=xp.iinfo(xp.uint8).max,
         gaussian_weights=True,
         use_sample_covariance=False,
     )
@@ -242,13 +261,15 @@ def test_gaussian_structural_similarity_vs_IPOL():
 @pytest.mark.parametrize(
     'dtype', [np.uint8, np.int32, np.float16, np.float32, np.float64]
 )
-def test_mssim_vs_legacy(dtype):
+def test_mssim_vs_legacy(dtype, xp):
     # check that ssim with default options matches skimage 0.17 result
     mssim_skimage_0pt17 = 0.3674518327910367
     assert cam.dtype == np.uint8
     assert cam_noisy.dtype == np.uint8
     mssim = structural_similarity(
-        cam.astype(dtype), cam_noisy.astype(dtype), data_range=255
+        xp.asarray(cam.astype(dtype)),
+        xp.asarray(cam_noisy.astype(dtype)),
+        data_range=255
     )
     assert_almost_equal(mssim, mssim_skimage_0pt17)
 
@@ -272,9 +293,10 @@ def test_ssim_warns_about_data_range():
     assert_almost_equal(mssim, mssim_mixed)
 
 
-@pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
-def test_structural_similarity_small_image(dtype):
-    X = np.zeros((5, 5), dtype=dtype)
+@pytest.mark.parametrize('dtype_str', ['float16', 'float32', 'float64'])
+def test_structural_similarity_small_image(dtype_str, xp):
+    dtype = getattr(xp, dtype_str)
+    X = xp.zeros((5, 5), dtype=dtype)
     # structural_similarity can be computed for small images if win_size is
     # a) odd and b) less than or equal to the images' smaller side
     xp_assert_equal(structural_similarity(X, X, win_size=3, data_range=1.0), 1.0)

--- a/tests/skimage2/metrics/test_structural_similarity.py
+++ b/tests/skimage2/metrics/test_structural_similarity.py
@@ -1,3 +1,4 @@
+import math
 import numpy as np
 import pytest
 from _skimage2.util._array_api import xp_assert_equal, assert_almost_equal
@@ -57,8 +58,8 @@ def test_structural_similarity_image(xp):
 # FIXME: Because we are forcing a random seed state, it is probably good to test
 #        against a few seeds in case on seed gives a particularly bad example
 @pytest.mark.parametrize('seed', [1, 2, 3, 5, 8, 13])
-@pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
-def test_structural_similarity_grad(seed, dtype, xp):
+@pytest.mark.parametrize('dtype_str', ['float16', 'float32', 'float64'])
+def test_structural_similarity_grad(seed, dtype_str, xp):
     N = 60
     # FIXME: This test is known to randomly fail on some systems (Mac OS X 10.6)
     #        And when testing tests in parallel. Therefore, we choose a few
@@ -66,9 +67,12 @@ def test_structural_similarity_grad(seed, dtype, xp):
     #        The likely cause of this failure is that we are setting a hard
     #        threshold on the value of the gradient. Often the computed gradient
     #        is only slightly larger than what was measured.
+    dtype_np = getattr(np, dtype_str)
+    dtype_xp = getattr(xp, dtype_str)
+
     rng = np.random.default_rng(seed)
-    X = rng.random((N, N)).astype(dtype, copy=False) * 255
-    Y = rng.random((N, N)).astype(dtype, copy=False) * 255
+    X = rng.random((N, N)).astype(dtype_np, copy=False) * 255
+    Y = rng.random((N, N)).astype(dtype_np, copy=False) * 255
 
     X = xp.asarray(X)
     Y = xp.asarray(Y)
@@ -79,14 +83,15 @@ def test_structural_similarity_grad(seed, dtype, xp):
     assert f < 0.05
 
     assert g[0] < 0.05
-    assert np.all(g[1] < 0.05)
+    assert xp.all(g[1] < 0.05)
 
     mssim, grad, s = structural_similarity(
         X, Y, data_range=255, gradient=True, full=True
     )
-    assert s.dtype == _supported_float_type(dtype)
-    assert grad.dtype == _supported_float_type(dtype)
-    assert np.all(grad < 0.05)
+
+    assert s.dtype == _supported_float_type(dtype_xp, xp=xp)
+    assert grad.dtype == _supported_float_type(dtype_xp, xp=xp)
+    assert xp.all(grad < 0.05)
 
 
 @pytest.mark.parametrize(
@@ -192,6 +197,7 @@ def test_structural_similarity_multichannel_chelsea(xp):
     Xc = data.chelsea()
     sigma = 15.0
     Yc = xp.clip(xp.asarray(Xc + sigma * np.random.randn(*Xc.shape)), 0, 255)
+    Xc = xp.asarray(Xc)
     Yc = xp.astype(Yc, Xc.dtype)
 
     # multichannel result should be mean of the individual channel results
@@ -200,10 +206,10 @@ def test_structural_similarity_multichannel_chelsea(xp):
         structural_similarity(Yc[..., c], Xc[..., c], data_range=255)
         for c in range(Xc.shape[-1])
     ]
-    assert_almost_equal(mssim, np.mean(mssim_sep))
+    assert_almost_equal(mssim, xp.mean(xp.asarray(mssim_sep)))
 
     # structural_similarity of image with itself should be 1.0
-    xp_assert_equal(structural_similarity(Xc, Xc, data_range=255, channel_axis=-1), 1.0)
+    assert structural_similarity(Xc, Xc, data_range=255, channel_axis=-1) == 1.0
 
 
 @pytest.mark.parametrize('gaussian_weights', [True, False])
@@ -255,7 +261,7 @@ def test_gaussian_structural_similarity_vs_IPOL(xp):
         gaussian_weights=True,
         use_sample_covariance=False,
     )
-    assert_almost_equal(mssim, mssim_IPOL, decimal=3)
+    assert math.isclose(mssim, mssim_IPOL, abs_tol=1.5e-3)
 
 
 @pytest.mark.parametrize(
@@ -271,7 +277,7 @@ def test_mssim_vs_legacy(dtype, xp):
         xp.asarray(cam_noisy.astype(dtype)),
         data_range=255
     )
-    assert_almost_equal(mssim, mssim_skimage_0pt17)
+    assert_almost_equal(xp.asarray(mssim), xp.asarray(mssim_skimage_0pt17))
 
 
 def test_ssim_warns_about_data_range():
@@ -299,8 +305,8 @@ def test_structural_similarity_small_image(dtype_str, xp):
     X = xp.zeros((5, 5), dtype=dtype)
     # structural_similarity can be computed for small images if win_size is
     # a) odd and b) less than or equal to the images' smaller side
-    xp_assert_equal(structural_similarity(X, X, win_size=3, data_range=1.0), 1.0)
-    xp_assert_equal(structural_similarity(X, X, win_size=5, data_range=1.0), 1.0)
+    assert structural_similarity(X, X, win_size=3, data_range=1.0) == 1.0
+    assert structural_similarity(X, X, win_size=5, data_range=1.0) == 1.0
     # structural_similarity errors for small images if user doesn't specify
     # win_size
     with pytest.raises(ValueError):


### PR DESCRIPTION
A companion to https://github.com/scikit-image/scikit-image/pull/8181: implement an initial POC support for Array API compatibility in `_skimage2/metrics/structural_similarity`.

With this PR, `structural_similarity` will natively support CuPy and PyTorch CPU tensors, provided
that scipy>=1.15.0. The support and the requirement come from
scipy.ndimage.{uniform_filter,gaussian_filter}`: structural_similarity uses these two scip
functions, and they support these two backends starting from scipy==1.15.0.

To test this locally, need to 

```
$ pip install array-api-compat array-api-extra scipy
# install cupy and/or pytorch if wanted
$ spin test tests/skimage2/metrics/test_structural_similarity.py -b all
```

or

```
$ SCIPY_ARRAY_API=1 spin ipython   # the env variable activates the Array API support
```

The PR has several moving parts. On a high level:

- structural_similarity itself has just a few changes, mainly it needs to find out the
namespace of inputs (NumPy, CuPy or PyTorch), and use array-api compatible analogs
of numpy functions (np.mean -> xp.mean etc);

- several tools need small updates to handle non-numpy array libraries. For one,
`convert_to_float` needs to convert to torch.float64 or numpy.float64, depending on the
input type;

- tests loop over the available backends via the new `xp` fixture;

- an update to `conftest.py` looks scary, yes. However, it's a literal copy-paste from
the SciPy's conftest, which has been stable for quite a while now. On a high level, it
only decides whether to activate the Array API support (via an environment variable), and
sets the infrastructure for looping over the backends.

- `spin` gets a new `-b` switch to select the backend:

```
$ spin test ....          # no change
$ spin test ... -b cupy   # runs tests with CuPy as the array provider
$ spin test ... -b all    # runs tests parametrized over all installed backends
```

- test assertions and several array-api utitilities are imported from scipy---this is
temporary and will change; assertions are going to be imported from array-api-extra once
https://github.com/scipy/scipy/pull/25143 is resolved;
Other utilities in `_array_api.py` will be vendored instead of being imported from scipy.

---------------------------------------------

This PR and https://github.com/scikit-image/scikit-image/pull/8181 are essentially POC / requests for comments: gh-8181 is a higher-level discussion, and this PR is just a (partially) worked example. I'd expect that this PR will need a rework or several, based on feedback. At this stage I suppose my main question would be whether this all makes  sense, and if not quite, what makes the least sense, so that I can work on that :-).

