### PR TITLE
ci: fix ccache reporting on windows and linux

### DIFF
--- a/.github/workflows/_build_linux_for_python_x.yaml
+++ b/.github/workflows/_build_linux_for_python_x.yaml
@@ -50,7 +50,6 @@ jobs:
           sudo apt-get install -y ccache
           sudo /usr/sbin/update-ccache-symlinks
           echo "/usr/lib/ccache" >> $GITHUB_PATH
-          ccache --zero-stats
 
       - name: Restore/save ccache
         uses: actions/cache@v4
@@ -59,6 +58,9 @@ jobs:
           key: ccache-${{ runner.os }}-py${{ inputs.python-version }}-${{ github.sha }}
           restore-keys: |
             ccache-${{ runner.os }}-py${{ inputs.python-version }}-
+
+      - name: Zero ccache stats
+        run: ccache --zero-stats
 
       - name: Build wheel
         run: |

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -76,12 +76,17 @@ jobs:
             ccache-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.OPTIONS_NAME }}-
             ccache-${{ runner.os }}-
 
+      - name: Zero ccache stats
+        shell: bash
+        run: ccache --zero-stats
+
       - name: Build skimage
         shell: bash
         run: |
           spin build
 
       - name: Show ccache stats
+        if: always()
         shell: bash
         run: ccache --show-stats
 


### PR DESCRIPTION
Follow up to #8185 to apply the same ccache clear logic before reporting, to get a better measure of usage.

Stats on Linux:

```
Run ccache --show-stats
Cacheable calls:    56 / 157 (35.67%)
  Hits:             56 /  56 (100.0%)
    Direct:         56 /  56 (100.0%)
    Preprocessed:    0 /  56 ( 0.00%)
  Misses:            0 /  56 ( 0.00%)
Uncacheable calls: 101 / 157 (64.33%)
Local storage:
  Cache size (GB): 0.0 / 0.4 ( 2.84%)
  Hits:             56 /  56 (100.0%)
  Misses:            0 /  56 ( 0.00%)
```

and on Windows:

```
Run ccache --show-stats
Cacheable calls:     56 /  56 (100.0%)
  Hits:              56 /  56 (100.0%)
    Direct:          56 /  56 (100.0%)
    Preprocessed:     0 /  56 ( 0.00%)
  Misses:             0 /  56 ( 0.00%)
Local storage:
  Cache size (GiB): 0.1 / 5.0 ( 1.03%)
  Hits:              56 /  56 (100.0%)
  Misses:             0 /  56 ( 0.00%)
```