### PR TITLE
TST: delete unnecessary pytest thread-unsafe marks

### DIFF
--- a/.github/workflows/_test_linux_for_python_x.yaml
+++ b/.github/workflows/_test_linux_for_python_x.yaml
@@ -132,7 +132,7 @@ jobs:
           PYTHONOPTIMIZE: ${{ inputs.PYTHONOPTIMIZE }}
         run: |
           pip install pytest-run-parallel
-          $PYTEST --doctest-plus --showlocals --pyargs skimage --parallel-threads=4 ./tests
+          spin test --doctest -- --parallel-threads=4
 
       - name: Check benchmarks
         run: |

--- a/tests/skimage/util/test_dtype.py
+++ b/tests/skimage/util/test_dtype.py
@@ -90,7 +90,6 @@ def test_range_extra_dtypes(dtype_in, dt):
     )
 
 
-@pytest.mark.thread_unsafe
 def test_downcast():
     x = np.arange(10).astype(np.uint64)
     with expected_warnings(['Downcasting']):
@@ -192,7 +191,6 @@ def test_float_conversion_dtype():
         assert y.dtype == np.dtype(dtype_out)
 
 
-@pytest.mark.thread_unsafe
 def test_float_conversion_dtype_warns():
     """Test that convert issues a warning when called"""
     from skimage.util.dtype import convert


### PR DESCRIPTION
Thanks @stefanv for pointing these out in #8065. I should have deleted them, they're leftover from #7678 and are unnecessary. In 3.14t, the warnings module is thread-safe. In any case on 3.13t, pytest-run-parallel will automatically mark tests that use the `warnings` module as thread-unsafe. These marks predate that.