### PR TITLE
ci: fix free-threading test invocation

### DIFF
--- a/.github/workflows/_test_linux_for_python_x.yaml
+++ b/.github/workflows/_test_linux_for_python_x.yaml
@@ -132,7 +132,7 @@ jobs:
           PYTHONOPTIMIZE: ${{ inputs.PYTHONOPTIMIZE }}
         run: |
           pip install pytest-run-parallel
-          $PYTEST --doctest-plus --showlocals --pyargs skimage --parallel-threads=4 ./tests
+          spin test --doctest -- --parallel-threads=4
 
       - name: Check benchmarks
         run: |


### PR DESCRIPTION
Fixes #8189 by using `spin test` directly to match the non free-threading pattern.