### PR TITLE
make phase cross correlation faster

### DIFF
--- a/src/skimage/registration/_phase_cross_correlation.py
+++ b/src/skimage/registration/_phase_cross_correlation.py
@@ -7,7 +7,7 @@ import itertools
 import warnings
 
 import numpy as np
-from scipy.fft import fftn, ifftn, fftfreq
+from scipy.fft import fftn, ifftn, fftfreq, next_fast_len
 from scipy import ndimage as ndi
 
 from ._masked_phase_cross_correlation import _masked_phase_cross_correlation
@@ -198,6 +198,19 @@ def _disambiguate_shift(reference_image, moving_image, shift):
 
     return np.array(real_shift_acc)
 
+def pad_to_fast(arr):
+    """
+    FFT is more efficient for composites of prime numbers.
+    Pad to the next fast shape
+    :param arr:
+    :return:
+    """
+    fast_shape = tuple(
+        next_fast_len(s) for s in arr.shape
+    )
+
+    pad_width = [(0, s - a) for a, s in zip(arr.shape, fast_shape)]
+    return np.pad(arr, pad_width, mode="constant")
 
 def phase_cross_correlation(
     reference_image,
@@ -332,8 +345,9 @@ def phase_cross_correlation(
         target_freq = moving_image
     # real data needs to be fft'd.
     elif space.lower() == 'real':
-        src_freq = fftn(reference_image)
-        target_freq = fftn(moving_image)
+        # pad to fast shape and cast to float32
+        src_freq = fftn(pad_to_fast(reference_image.astype(np.float32, copy=False)))
+        target_freq = fftn(pad_to_fast(moving_image.astype(np.float32, copy=False)))
     else:
         raise ValueError('space argument must be "real" of "fourier"')
 

--- a/src/skimage/registration/_phase_cross_correlation.py
+++ b/src/skimage/registration/_phase_cross_correlation.py
@@ -198,17 +198,20 @@ def _disambiguate_shift(reference_image, moving_image, shift):
 
     return np.array(real_shift_acc)
 
-def pad_to_fast(arr):
-    """
-    FFT is more efficient for composites of prime numbers.
-    Pad to the next fast shape
-    :param arr:
-    :return:
-    """
-    fast_shape = tuple(
-        next_fast_len(s) for s in arr.shape
-    )
+def _pad_to_fast(arr):
+    """Pad array to the next FFT-friendly size along each axis.
 
+    Parameters
+    ----------
+    arr : ndarray
+        Input array.
+
+    Returns
+    -------
+    ndarray
+        Zero-padded array whose shape is 5-smooth (composed of factors 2, 3, 5).
+    """
+    fast_shape = tuple(next_fast_len(s) for s in arr.shape)
     pad_width = [(0, s - a) for a, s in zip(arr.shape, fast_shape)]
     return np.pad(arr, pad_width, mode="constant")
 

--- a/src/skimage/registration/_phase_cross_correlation.py
+++ b/src/skimage/registration/_phase_cross_correlation.py
@@ -349,8 +349,8 @@ def phase_cross_correlation(
     # real data needs to be fft'd.
     elif space.lower() == 'real':
         # pad to fast shape and cast to float32
-        src_freq = fftn(pad_to_fast(reference_image.astype(np.float32, copy=False)))
-        target_freq = fftn(pad_to_fast(moving_image.astype(np.float32, copy=False)))
+        src_freq = fftn(_pad_to_fast(reference_image.astype(np.float32, copy=False)))
+        target_freq = fftn(_pad_to_fast(moving_image.astype(np.float32, copy=False)))
     else:
         raise ValueError('space argument must be "real" of "fourier"')
 

--- a/src/skimage/registration/_phase_cross_correlation.py
+++ b/src/skimage/registration/_phase_cross_correlation.py
@@ -348,9 +348,13 @@ def phase_cross_correlation(
         target_freq = moving_image
     # real data needs to be fft'd.
     elif space.lower() == 'real':
-        # pad to fast shape and cast to float32
-        src_freq = fftn(_pad_to_fast(reference_image.astype(np.float32, copy=False)))
-        target_freq = fftn(_pad_to_fast(moving_image.astype(np.float32, copy=False)))
+        # Cast ints to float32 to prevent them being cast to float64
+        if np.isdtype(reference_image.dtype, 'integral'):
+            reference_image.astype(np.float32, copy=False)
+            moving_image.astype(np.float32, copy=False)
+        # Pad to fast shape
+        src_freq = fftn(_pad_to_fast(reference_image))
+        target_freq = fftn(_pad_to_fast(moving_image))
     else:
         raise ValueError('space argument must be "real" of "fourier"')
 

--- a/tests/skimage/registration/test_phase_cross_correlation.py
+++ b/tests/skimage/registration/test_phase_cross_correlation.py
@@ -6,13 +6,12 @@ import pytest
 from numpy.testing import assert_allclose
 from scipy.ndimage import fourier_shift
 import scipy.fft as fft
-import timeit
 
 from skimage import img_as_float
 from _skimage2._shared._warnings import expected_warnings
 from _skimage2._shared.testing import assert_stacklevel
 from _skimage2._shared.utils import _supported_float_type
-from skimage.data import camera, binary_blobs, eagle, cell, retina
+from skimage.data import camera, binary_blobs, eagle
 from skimage.registration._phase_cross_correlation import (
     phase_cross_correlation,
     _upsampled_dft,
@@ -250,18 +249,3 @@ def test_disambiguate_empty_image(null_images):
     assert len(records) == 2
     assert "Could not determine real-space shift" in records[0].message.args[0]
     assert "Could not determine RMS error between images" in records[1].message.args[0]
-
-
-def test_speed():
-    reference_image = retina()[:1021, :1031, 0] # worse case scenario for fft algo
-    subpixel_shift = (-2.4, 1.32)
-    shifted_image = fourier_shift(fft.fftn(reference_image), subpixel_shift)
-    shifted_image = fft.ifftn(shifted_image).real
-
-    time = timeit.timeit(
-        lambda: phase_cross_correlation(
-        reference_image, shifted_image, upsample_factor=100
-    ), number=100
-    )
-    print(time)
-    assert time < 10

--- a/tests/skimage/registration/test_phase_cross_correlation.py
+++ b/tests/skimage/registration/test_phase_cross_correlation.py
@@ -6,12 +6,13 @@ import pytest
 from numpy.testing import assert_allclose
 from scipy.ndimage import fourier_shift
 import scipy.fft as fft
+import timeit
 
 from skimage import img_as_float
 from _skimage2._shared._warnings import expected_warnings
 from _skimage2._shared.testing import assert_stacklevel
 from _skimage2._shared.utils import _supported_float_type
-from skimage.data import camera, binary_blobs, eagle
+from skimage.data import camera, binary_blobs, eagle, cell, retina
 from skimage.registration._phase_cross_correlation import (
     phase_cross_correlation,
     _upsampled_dft,
@@ -249,3 +250,18 @@ def test_disambiguate_empty_image(null_images):
     assert len(records) == 2
     assert "Could not determine real-space shift" in records[0].message.args[0]
     assert "Could not determine RMS error between images" in records[1].message.args[0]
+
+
+def test_speed():
+    reference_image = retina()[:1021, :1031, 0] # worse case scenario for fft algo
+    subpixel_shift = (-2.4, 1.32)
+    shifted_image = fourier_shift(fft.fftn(reference_image), subpixel_shift)
+    shifted_image = fft.ifftn(shifted_image).real
+
+    time = timeit.timeit(
+        lambda: phase_cross_correlation(
+        reference_image, shifted_image, upsample_factor=100
+    ), number=100
+    )
+    print(time)
+    assert time < 10


### PR DESCRIPTION
<!--
Please see the Contribution Guide:
https://scikit-image.org/docs/dev/development/contribute.html
For newcomers: this document has a checklist of what we expect in a PR.

Also please note our AI policy:
https://scikit-image.org/docs/dev/development/contribute.html#ai-policy
-->

We found a couple of performance improvements for `phase_cross_correlation` in `real` space. By we I mean @daniela-camgile, I am just spreading the knowledge up the stream. No AI used, probably would have helped.

1. Forcing images to `float32` saves a lot of time on recasting further down the line. This is indeed reducing the default accuracy from `float64`. But real world images are often lower bit depth than that. If we reduce time by half and not lose accuracy for these cases, I think it is worth it. 
2. Padding to `next_fast_len` makes a significant difference for images that are multiples of big primes

The implementation is very much a stub. I added a test (which I then removed so the tests would not shout at me) to compare some numbers. Here is what I get on my local Windows machine when I run that test:

| main version    | cast to float32 | cast to float32 and pad_to_fast |
| -------- | ------- | -------------|
| 18.1 s   | 10.9 s    | 7.1 s |

Happy keep improving this PR and incorporate any thoughts, concerns, ideas or be told we are misusing the method.
Started a topic [here](https://discuss.scientific-python.org/t/precision-in-fftn-for-phase-cross-correlation/2351?u=elena-pascal)
### Release note (optional)

<!-- See https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes -->

```release-note
...
```
