### PR TITLE
BUG: local_binary_pattern platform mismatch fix

### DIFF
--- a/src/skimage/feature/_texture.pyx
+++ b/src/skimage/feature/_texture.pyx
@@ -124,6 +124,7 @@ def _local_binary_pattern(cnp.float64_t[:, ::1] image,
 
     # pre-allocate arrays for computation
     cdef cnp.float64_t[::1] texture = np.zeros(P, dtype=np.float64)
+    cdef cnp.float64_t epsilon = 1e-12
     cdef signed char[::1] signed_texture = np.zeros(P, dtype=np.int8)
     cdef int[::1] rotation_chain = np.zeros(P, dtype=np.int32)
 
@@ -150,7 +151,7 @@ def _local_binary_pattern(cnp.float64_t[:, ::1] image,
                             b'C', 0, &texture[i])
                 # signed / thresholded texture
                 for i in range(P):
-                    if texture[i] - image[r, c] >= 0:
+                    if texture[i] - image[r, c] >= -epsilon:
                         signed_texture[i] = 1
                     else:
                         signed_texture[i] = 0

--- a/tests/skimage/feature/test_texture.py
+++ b/tests/skimage/feature/test_texture.py
@@ -262,6 +262,22 @@ class TestLBP:
         )
         np.testing.assert_array_equal(lbp, ref)
 
+
+    def test_linux_mac_portability(self):
+        try:
+            import sklearn
+        except ImportError:
+            pytest.skip("test requires sklearn")
+        from sklearn.datasets import fetch_openml
+        dataset = fetch_openml("Fashion-MNIST")
+        X = dataset.data
+        images = X.to_numpy().reshape(-1, 28, 28)
+        image = images[135]
+        LBP = local_binary_pattern(image, P=16, R=2, method="uniform")
+        actual = LBP[-8][11:15]
+        np.testing.assert_array_equal(actual, [11, 9, 11, 13])
+
+
     def test_ror(self):
         lbp = local_binary_pattern(self.image, 8, 1, 'ror')
         ref = np.array(

--- a/tests/skimage/feature/test_texture.py
+++ b/tests/skimage/feature/test_texture.py
@@ -263,7 +263,7 @@ class TestLBP:
         np.testing.assert_array_equal(lbp, ref)
 
 
-    def test_linux_mac_portability(self):
+    def test_gh_8198(self):
         try:
             import sklearn
         except ImportError:


### PR DESCRIPTION
Fixes gh-8198.

* Side-by-side debug printing between MacOS and Linux for the Cython code underlying the regression test added here indicated a first point of deviation between platforms that was related to a floating point comparison with `0`. For the image associated with this regression test, the delta values were `-2.842170943040401e-14` and `0.0` (based on what gets printed at least, after temporarily removing the `nogil` block to debug).

* The full testsuite seem to pass locally on Linux x86_64 and Mac OS ARM on this feature branch, and the test seems to fail before and pass after the patch.

AI disclosure: I used Claude Sonnet 4.5 on our internal AI portal to probe the source code of the `_local_binary_pattern()` Cython function and rank the most likely locations for platform-specific differences. I've reproduced that ranking below the fold. That helped me narrow down the debug print locations, which I then ran on both platforms and diffed the verbose output to identify the first point of platform-specific deviation.

<details>

<img width="788" height="991" alt="image" src="https://github.com/user-attachments/assets/649bb288-90ad-479e-9d95-b2ffac2ff803" />


</details>