### PR TITLE
Fix platform-dependent local_binary_pattern via exact-at-equal-endpoints interpolation

### DIFF
--- a/src/_skimage2/_shared/interpolation.pxd
+++ b/src/_skimage2/_shared/interpolation.pxd
@@ -112,9 +112,16 @@ cdef inline void bilinear_interpolation(
     cdef np_real_numeric bottom_left = get_pixel2d(image, rows, cols, maxr, minc, mode, cval)
     cdef np_real_numeric bottom_right = get_pixel2d(image, rows, cols, maxr, maxc, mode, cval)
 
-    top = (1 - dc) * top_left + dc * top_right
-    bottom = (1 - dc) * bottom_left + dc * bottom_right
-    out[0] = <np_real_numeric_out> ((1 - dr) * top + dr * bottom)
+    # Linear interpolation form ``v0 + t * (v1 - v0)`` instead of ``(1 - t) * v0 + t * v1``.
+    # When the two endpoints are equal the difference is exactly zero, so the
+    # result is exactly that endpoint regardless of ``t`` and of how the
+    # compiler contracts the multiply-add (FMA). This removes a class of
+    # platform-specific (e.g. x86 vs ARM) last-bit discrepancies that flip
+    # downstream threshold comparisons, see #8198. The endpoints are cast to
+    # float before subtracting to avoid wraparound for unsigned integer images.
+    top = top_left + dc * (<np_floats>top_right - <np_floats>top_left)
+    bottom = bottom_left + dc * (<np_floats>bottom_right - <np_floats>bottom_left)
+    out[0] = <np_real_numeric_out> (top + dr * (bottom - top))
 
 cdef inline np_floats quadratic_interpolation(np_floats x,
                                               np_real_numeric[3] f) noexcept nogil:

--- a/tests/skimage/feature/test_texture.py
+++ b/tests/skimage/feature/test_texture.py
@@ -262,6 +262,35 @@ class TestLBP:
         )
         np.testing.assert_array_equal(lbp, ref)
 
+    def test_uniform_platform_consistency_gh_8198(self):
+        # Regression test for #8198: local_binary_pattern returned different
+        # results on x86 (no FMA) and ARM (FMA). The bilinear-interpolation
+        # threshold ``texture[i] - image[r, c] >= 0`` flipped on a sub-ULP delta
+        # that one platform rounded to a tiny negative value and the other to 0.
+        #
+        # This 9x11 patch is rows 16:25, cols 7:18 of item 135 of Fashion-MNIST
+        # (the case reported in #8198); the affected output is ``lbp[4][4:8]``.
+        # With the old ``(1 - t) * v0 + t * v1`` interpolation this slice was
+        # ``[11, 8, 11, 13]`` on x86 and ``[11, 9, 11, 13]`` on ARM; both now
+        # agree on ``[11, 9, 11, 13]``. The patch is inlined (no network/sklearn
+        # dependency) so the test is deterministic and offline.
+        image = np.array(
+            [
+                [0, 41, 255, 216, 220, 219, 218, 219, 219, 219, 221],
+                [0, 135, 254, 217, 219, 219, 219, 219, 219, 220, 219],
+                [0, 190, 249, 216, 220, 220, 220, 221, 221, 222, 220],
+                [0, 223, 236, 219, 220, 220, 221, 222, 222, 222, 222],
+                [14, 234, 229, 220, 221, 221, 221, 221, 221, 221, 221],
+                [8, 246, 225, 220, 221, 221, 221, 221, 221, 221, 220],
+                [0, 253, 223, 222, 222, 222, 222, 223, 222, 223, 221],
+                [0, 253, 217, 218, 217, 218, 218, 217, 217, 217, 218],
+                [0, 255, 230, 227, 227, 227, 227, 227, 227, 227, 228],
+            ],
+            dtype=np.uint8,
+        )
+        lbp = local_binary_pattern(image, P=16, R=2, method="uniform")
+        np.testing.assert_array_equal(lbp[4][4:8], [11, 9, 11, 13])
+
     def test_ror(self):
         lbp = local_binary_pattern(self.image, 8, 1, 'ror')
         ref = np.array(

--- a/tests/skimage/feature/test_texture.py
+++ b/tests/skimage/feature/test_texture.py
@@ -272,8 +272,7 @@ class TestLBP:
         # (the case reported in #8198); the affected output is ``lbp[4][4:8]``.
         # With the old ``(1 - t) * v0 + t * v1`` interpolation this slice was
         # ``[11, 8, 11, 13]`` on x86 and ``[11, 9, 11, 13]`` on ARM; both now
-        # agree on ``[11, 9, 11, 13]``. The patch is inlined (no network/sklearn
-        # dependency) so the test is deterministic and offline.
+        # agree on ``[11, 9, 11, 13]``.
         image = np.array(
             [
                 [0, 41, 255, 216, 220, 219, 218, 219, 219, 219, 221],

--- a/tests/skimage/feature/test_texture.py
+++ b/tests/skimage/feature/test_texture.py
@@ -264,7 +264,7 @@ class TestLBP:
 
     def test_uniform_platform_consistency_gh_8198(self):
         # Regression test for #8198: local_binary_pattern returned different
-        # results on x86 (no FMA) and ARM (FMA). The bilinear-interpolation
+        # results on x86 (no Fused Multiply-Add) and ARM (FMA). The bilinear-interpolation
         # threshold ``texture[i] - image[r, c] >= 0`` flipped on a sub-ULP delta
         # that one platform rounded to a tiny negative value and the other to 0.
         #

--- a/tests/skimage/transform/test_warps.py
+++ b/tests/skimage/transform/test_warps.py
@@ -53,6 +53,30 @@ def test_warp_tform():
     assert_array_almost_equal(x90, np.rot90(x))
 
 
+def test_warp_bilinear_constant_region_is_exact():
+    # Regression test for #8198. Bilinear interpolation (order=1) uses the
+    # linear interpolation form ``v0 + t * (v1 - v0)``, so interpolating anywhere
+    # inside a region of equal pixels must return that value *exactly*
+    # (bit-for-bit), regardless of the sub-pixel position or of how the compiler
+    # contracts the multiply-add (FMA). The previous ``(1 - t) * v0 + t * v1`` form
+    # was only exact at the grid points; off-grid it produced sub-ULP deltas whose
+    # sign depended on the platform (e.g. x86 two-rounding vs ARM FMA), which
+    # flipped downstream threshold comparisons (such as in
+    # ``local_binary_pattern``) inconsistently across platforms. Sweep several
+    # sub-pixel offsets and rotations so the invariant is exercised broadly.
+    value = 7.3
+    image = np.full((7, 7), value, dtype=np.float64)
+    expected = np.full_like(image, value)
+    for rotation in (0.0, 0.123, 0.5):
+        for tx, ty in [(0.37, 0.42), (0.1, 0.9), (0.5, 0.25), (0.73, 0.66)]:
+            tform = SimilarityTransform(
+                scale=1, rotation=rotation, translation=(-tx, ty)
+            )
+            warped = warp(image, tform, order=1, mode='edge')
+            # Compare on the exact bit pattern, not an approximate tolerance.
+            assert_array_equal(warped, expected)
+
+
 def test_warp_callable():
     x = np.zeros((5, 5), dtype=np.float64)
     x[2, 2] = 1

--- a/tests/skimage/transform/test_warps.py
+++ b/tests/skimage/transform/test_warps.py
@@ -53,30 +53,6 @@ def test_warp_tform():
     assert_array_almost_equal(x90, np.rot90(x))
 
 
-def test_warp_bilinear_constant_region_is_exact():
-    # Regression test for #8198. Bilinear interpolation (order=1) uses the
-    # linear interpolation form ``v0 + t * (v1 - v0)``, so interpolating anywhere
-    # inside a region of equal pixels must return that value *exactly*
-    # (bit-for-bit), regardless of the sub-pixel position or of how the compiler
-    # contracts the multiply-add (FMA). The previous ``(1 - t) * v0 + t * v1`` form
-    # was only exact at the grid points; off-grid it produced sub-ULP deltas whose
-    # sign depended on the platform (e.g. x86 two-rounding vs ARM FMA), which
-    # flipped downstream threshold comparisons (such as in
-    # ``local_binary_pattern``) inconsistently across platforms. Sweep several
-    # sub-pixel offsets and rotations so the invariant is exercised broadly.
-    value = 7.3
-    image = np.full((7, 7), value, dtype=np.float64)
-    expected = np.full_like(image, value)
-    for rotation in (0.0, 0.123, 0.5):
-        for tx, ty in [(0.37, 0.42), (0.1, 0.9), (0.5, 0.25), (0.73, 0.66)]:
-            tform = SimilarityTransform(
-                scale=1, rotation=rotation, translation=(-tx, ty)
-            )
-            warped = warp(image, tform, order=1, mode='edge')
-            # Compare on the exact bit pattern, not an approximate tolerance.
-            assert_array_equal(warped, expected)
-
-
 def test_warp_callable():
     x = np.zeros((5, 5), dtype=np.float64)
     x[2, 2] = 1


### PR DESCRIPTION
Use linear interpolation form ``v0 + t * (v1 - v0)`` instead of ``(1 - t) * v0 + t * v1``. When the two endpoints are equal the difference is exactly zero, so the result is exactly that endpoint regardless of ``t`` and of how the compiler contracts the multiply-add (FMA). This removes a class of platform-specific (e.g. x86 vs ARM) last-bit discrepancies that flip downstream threshold comparisons, see #8198. The endpoints are cast to float before subtracting to avoid wraparound for unsigned integer images.

Fixes: https://github.com/scikit-image/scikit-image/issues/8198

Relates: https://github.com/scikit-image/scikit-image/pull/8201

### Release note (optional)

<!-- See https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes -->

```release-note
Fix platform-dependent local_binary_pattern via exact-at-equal-endpoints interpolation
```

#### AI Generation Disclosure

Claude Code (Anthropic, Opus 4.8) was used to investigate the root cause, write
the fix and the regression tests. All AI-generated code and text were reviewed by the author.
