### PR TITLE
Use defined state for random generator

### DIFF
--- a/tests/skimage2/metrics/test_structural_similarity.py
+++ b/tests/skimage2/metrics/test_structural_similarity.py
@@ -85,8 +85,9 @@ def test_structural_similarity_grad(seed, dtype):
 )
 def test_structural_similarity_dtype(dtype):
     N = 30
-    X = np.random.rand(N, N)
-    Y = np.random.rand(N, N)
+    rng = np.random.default_rng(1234)
+    X = rng.random((N, N))
+    Y = rng.random((N, N))
     if np.dtype(dtype).kind in 'iub':
         data_range = 255.0
         X = (X * 255).astype(dtype)


### PR DESCRIPTION
Fix flaky unit test by specifying random generator

Failing unit test: https://github.com/scikit-image/scikit-image/actions/runs/26684453271/job/78650310711?pr=8207


### Release note (optional)

<!-- See https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes -->

```release-note
Fix flaky unit test `test_structural_similarity`
```
