### PR TITLE
Support lower-dimensional templates in match_template

### DIFF
--- a/src/skimage/feature/template.py
+++ b/src/skimage/feature/template.py
@@ -50,7 +50,12 @@ def match_template(
     template : (m, n[, p]) array
         Template to locate. It must be `(m <= M, n <= N[, p <= P])`.
         If `template` has fewer dimensions than `image`, singleton
-        dimensions are appended to match `image.ndim`.
+        dimensions are appended to match `image.ndim`. For example, a
+        2-D template matched against a 3-D image is treated as a template
+        with shape ``(m, n, 1)``. This applies the same 2-D template
+        independently along the final image axis and returns one response
+        plane per channel or layer, with shape ``(M - m + 1, N - n + 1, P)``
+        when `pad_input=False`.
     pad_input : bool
         If True, pad `image` so that output is the same size as the image, and
         output values correspond to the template center. Otherwise, the output

--- a/src/skimage/feature/template.py
+++ b/src/skimage/feature/template.py
@@ -49,6 +49,8 @@ def match_template(
         2-D or 3-D input image.
     template : (m, n[, p]) array
         Template to locate. It must be `(m <= M, n <= N[, p <= P])`.
+        If `template` has fewer dimensions than `image`, singleton
+        dimensions are appended to match `image.ndim`.
     pad_input : bool
         If True, pad `image` so that output is the same size as the image, and
         output values correspond to the template center. Otherwise, the output
@@ -120,6 +122,8 @@ def match_template(
             "Dimensionality of template must be less than or "
             "equal to the dimensionality of image."
         )
+    if image.ndim > template.ndim:
+        template = template[(...,) + (np.newaxis,) * (image.ndim - template.ndim)]
     if np.any(np.less(image.shape, template.shape)):
         raise ValueError("Image must be larger than template.")
 

--- a/tests/skimage/feature/test_template.py
+++ b/tests/skimage/feature/test_template.py
@@ -150,6 +150,12 @@ def test_3d_image_with_2d_template():
     assert_equal(result.shape, (10, 10, 5))
     assert_allclose(result, expected)
 
+    padded_result = match_template(image, template, pad_input=True)
+    padded_expected = match_template(image, template[..., np.newaxis], pad_input=True)
+
+    assert_equal(padded_result.shape, (12, 12, 5))
+    assert_allclose(padded_result, padded_expected)
+
 
 def test_3d_pad_input():
     rng = np.random.RandomState(3122599642)

--- a/tests/skimage/feature/test_template.py
+++ b/tests/skimage/feature/test_template.py
@@ -1,5 +1,5 @@
 import numpy as np
-from _skimage2._shared.testing import assert_almost_equal, assert_equal
+from _skimage2._shared.testing import assert_almost_equal, assert_allclose, assert_equal
 
 from skimage import data, img_as_float
 from skimage.morphology import diamond
@@ -137,6 +137,18 @@ def test_3d():
 
     assert_equal(result.shape, (10, 10, 10))
     assert_equal(np.unravel_index(result.argmax(), result.shape), (3, 5, 4))
+
+
+def test_3d_image_with_2d_template():
+    rng = np.random.RandomState(28378128)
+    template = rng.rand(3, 3)
+    image = rng.rand(12, 12, 5)
+
+    result = match_template(image, template)
+    expected = match_template(image, template[..., np.newaxis])
+
+    assert_equal(result.shape, (10, 10, 5))
+    assert_allclose(result, expected)
 
 
 def test_3d_pad_input():


### PR DESCRIPTION
## Summary

- Append singleton axes to `template` when it has fewer dimensions than the input image.
- Document that lower-dimensional templates are expanded to match `image.ndim`.
- Add a regression test for using a 2D template against a 3D image.

## Details

`match_template` already accepted `template.ndim <= image.ndim`, but later shape checks and convolution code assumed both operands had the same number of axes. That meant a 2D template with a 3D image failed with an internal NumPy broadcasting error before the documented size validation could run.

The new test verifies that `match_template(image_3d, template_2d)` matches the explicit `match_template(image_3d, template_2d[..., np.newaxis])` behavior suggested in #8171.

Closes #8171.

## Validation

- `python -m pytest tests/skimage/feature/test_template.py::test_3d_image_with_2d_template -q -o addopts=''`
- `python -m pytest tests/skimage/feature/test_template.py -q -o addopts=''`