### PR TITLE
Allow positional `blob_size` param in `binary_blobs`

### DIFF
--- a/src/_skimage2/data/_synthetic.py
+++ b/src/_skimage2/data/_synthetic.py
@@ -8,8 +8,8 @@ from .._shared._warnings import warn_external
 
 def binary_blobs(
     shape,
-    *,
     blob_size,
+    *,
     volume_fraction=0.5,
     rng=None,
     boundary_mode='wrap',

--- a/tests/skimage2/data/test_synthetic.py
+++ b/tests/skimage2/data/test_synthetic.py
@@ -10,6 +10,11 @@ SEED = 3  # Pin randomness of tests
 
 
 class Test_binary_blobs:
+    def test_required_args_positional(self):
+        blobs_kw = binary_blobs(shape=(32, 32), blob_size=5, rng=SEED)
+        blobs_pos = binary_blobs((32, 32), 5, rng=SEED)
+        np.testing.assert_array_equal(blobs_kw, blobs_pos)
+
     def test_volume_fraction(self):
         blobs = binary_blobs(shape=(128, 128), blob_size=13, rng=SEED)
         assert_almost_equal(blobs.mean(), 0.5, decimal=1)


### PR DESCRIPTION
See:
https://skimage.zulipchat.com/#narrow/channel/181448-development/topic/Input.20argument.20policies/with/600338514
for discussion.

Cursor reviewed by MB.
