### PR TITLE
Check all eight cube corners against mask in marching_cubes

### DIFF
--- a/src/_skimage2/measure/_marching_cubes_lewiner.py
+++ b/src/_skimage2/measure/_marching_cubes_lewiner.py
@@ -54,7 +54,8 @@ def marching_cubes(
         Whether the method of Lewiner et al. or Lorensen et al. will be used.
     mask : (M, N, P) array, optional
         Boolean array. The marching cube algorithm will be computed only on
-        True elements. This will save computational time when interfaces
+        True elements. A cube is processed only if all eight of its corner
+        voxels are True. This will save computational time when interfaces
         are located within certain region of the volume M, N, P-e.g. the top
         half of the cube-and also allow to compute finite surfaces-i.e. open
         surfaces that do not end at the border of the cube.

--- a/src/_skimage2/measure/_marching_cubes_lewiner_cy.pyx
+++ b/src/_skimage2/measure/_marching_cubes_lewiner_cy.pyx
@@ -980,7 +980,12 @@ def marching_cubes(cnp.float32_t[:, :, :] im not None, cnp.float64_t isovalue,
             while x < Nx_bound:
                 x += st
                 x_st = x + st
-                if no_mask or mask[z_st, y_st, x_st]:
+                # Only compute a cube if all eight of its corners are
+                # unmasked; checking a single corner leaves boundary
+                # positions unreachable by the mask (gh-8202).
+                if no_mask or (
+                        mask[z   ,y, x] and mask[z   ,y, x_st] and mask[z   ,y_st, x_st] and mask[z   ,y_st, x] and
+                        mask[z_st,y, x] and mask[z_st,y, x_st] and mask[z_st,y_st, x_st] and mask[z_st,y_st, x]):
                     # Initialize cell
                     cell.set_cube(isovalue, x, y, z, st,
                         im[z   ,y, x], im[z   ,y, x_st], im[z   ,y_st, x_st], im[z   ,y_st, x],

--- a/tests/skimage/measure/test_marching_cubes.py
+++ b/tests/skimage/measure/test_marching_cubes.py
@@ -165,7 +165,23 @@ def test_masked_marching_cubes():
     ver, faces, _, _ = marching_cubes(ellipsoid_scalar, 0, mask=mask)
     area = mesh_surface_area(ver, faces)
 
-    assert_allclose(area, 299.56878662109375, rtol=0.01)
+    # Surface area of the unmasked region only; no vertex may fall on a
+    # masked voxel.
+    assert_allclose(area, 243.14218, rtol=0.01)
+    assert ver[:, 0].min() >= 10
+    assert ver[:, 2].max() <= 19
+
+
+def test_masked_marching_cubes_masked_corner_excludes_cube():
+    # Masking any single corner of the only cube must exclude that cube,
+    # including position 0 which was never checked before. See gh-8202.
+    vol = np.full((2, 2, 2), -1.0)
+    vol[0, 0, 0] = 1.0
+    for corner in np.ndindex(2, 2, 2):
+        mask = np.ones_like(vol, dtype=bool)
+        mask[corner] = False
+        with pytest.raises(RuntimeError):
+            marching_cubes(vol, 0, mask=mask)
 
 
 def test_masked_marching_cubes_empty():

--- a/tests/skimage2/measure/test_marching_cubes.py
+++ b/tests/skimage2/measure/test_marching_cubes.py
@@ -165,7 +165,23 @@ def test_masked_marching_cubes():
     ver, faces, _, _ = marching_cubes(ellipsoid_scalar, 0, mask=mask)
     area = mesh_surface_area(ver, faces)
 
-    assert_allclose(area, 299.56878662109375, rtol=0.01)
+    # Surface area of the unmasked region only; no vertex may fall on a
+    # masked voxel.
+    assert_allclose(area, 243.14218, rtol=0.01)
+    assert ver[:, 0].min() >= 10
+    assert ver[:, 2].max() <= 19
+
+
+def test_masked_marching_cubes_masked_corner_excludes_cube():
+    # Masking any single corner of the only cube must exclude that cube,
+    # including position 0 which was never checked before. See gh-8202.
+    vol = np.full((2, 2, 2), -1.0)
+    vol[0, 0, 0] = 1.0
+    for corner in np.ndindex(2, 2, 2):
+        mask = np.ones_like(vol, dtype=bool)
+        mask[corner] = False
+        with pytest.raises(RuntimeError):
+            marching_cubes(vol, 0, mask=mask)
 
 
 def test_masked_marching_cubes_empty():


### PR DESCRIPTION
## Description

Fixes #8202.

`marching_cubes` with a `mask` never consults positions with index 0 in any dimension. The inner loop gates each cube on its far corner (`mask[z_st, y_st, x_st]`), and since cube origins run `0..N-2`, the checked indices run `1..N-1`. Masking `[0, 0, 0]` does nothing, while masking `[1, 1, 1]` excludes the first cube. The repro in the issue shows it.

Swapping the check to the origin corner would just mirror the problem: the planes at index `N-1` would become dead instead, and cubes touching a masked far corner would still be computed. Neither single-corner convention matches the docstring ("computed only on True elements"), because the algorithm reads eight voxels per cube.

So this gates each cube on all eight corners it reads. A cube is computed only if every voxel it samples is unmasked. Effects:

- Masking any voxel now excludes every cube that samples it. Both boundaries behave the same, no dead planes.
- The surface can no longer extend into the masked region. The expected area in `test_masked_marching_cubes` changes from 299.57 to 243.14: the old surface leaked one cube layer past the lower-z mask boundary (it had vertices at z=9, inside the masked region; now it starts at z=10). I added extent assertions so that property is pinned, not just the area value.
- Overhead is small. With an all-True mask on a ~1M voxel volume I measure 11.5 ms vs 10.8 ms unmasked (the `and` chain short-circuits, and the eight reads are the same voxels `set_cube` loads right after).

The new test masks each of the 8 corners of a single-cube volume in turn and asserts the cube is excluded every time. On main it fails for every corner except `[1, 1, 1]`.

Tool disclosure, per the AI policy: I used Claude Code while investigating and drafting this change. I've reviewed every line, and the analysis and measurements above were run locally.

### Release note (optional)

```release-note
Fix mask handling in `skimage.measure.marching_cubes`: a cube is now
computed only if all eight of its corner voxels are unmasked. Previously
voxels with index 0 along any dimension could never be masked, and the
computed surface could extend one cube into the masked region.
```
