### PR TITLE
Ignore pyenv virtualenv env name marker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ skimage/morphology/_skeletonize_lee_cy.pyx
 .vscode/
 .mesonpy-native-file.ini
 stubs/
+# pyenv virtualenv environment marker.
+.python-version


### PR DESCRIPTION
File gives pyenv virtualenv environment name.  I use this for all my
local testing trees.

[skip ci]
