### PR TITLE
Harmonize doctest imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,6 +237,9 @@ filterwarnings = [
     "ignore:.*(parseString|resetCache|enablePackrat|oneOf).*:DeprecationWarning:matplotlib",
     # tifffile (v2025.12.20) uses deprecated NumPy API
     "ignore:Setting the shape on a NumPy array:DeprecationWarning:tifffile",
+    # SimpleITK (< 3.0) uses deprecated NumPy API; fixed in SimpleITK 3.0
+    # TODO: remove once SimpleITK >= 3.0 is required
+    "ignore:Setting the shape on a NumPy array:DeprecationWarning:SimpleITK",
     # pytest warning when running under PYTHONOPTIMIZE=2 (assertions are stripped)
     "ignore:assertions not in test modules or plugins:pytest.PytestConfigWarning",
 ]

--- a/src/_skimage2/color/colorconv.py
+++ b/src/_skimage2/color/colorconv.py
@@ -386,6 +386,7 @@ def hsv2rgb(hsv, *, channel_axis=-1):
     Examples
     --------
     >>> from _skimage2 import data
+    >>> from _skimage2.color import rgb2hsv
     >>> img = data.astronaut()
     >>> img_hsv = rgb2hsv(img)
     >>> img_rgb = hsv2rgb(img_hsv)

--- a/src/_skimage2/feature/texture.py
+++ b/src/_skimage2/feature/texture.py
@@ -227,6 +227,7 @@ def graycoprops(P, prop='contrast'):
     ...                   [0, 0, 1, 1],
     ...                   [0, 2, 2, 2],
     ...                   [2, 2, 3, 3]], dtype=np.uint8)
+    >>> from _skimage2.feature import graycomatrix
     >>> g = graycomatrix(image, [1, 2], [0, np.pi/2], levels=4,
     ...                  normed=True, symmetric=True)
     >>> contrast = graycoprops(g, 'contrast')

--- a/src/_skimage2/graph/_rag.py
+++ b/src/_skimage2/graph/_rag.py
@@ -33,6 +33,7 @@ def _edge_generator_from_csr(csr_array):
     Examples
     --------
 
+    >>> from scipy import sparse
     >>> dense = np.eye(2, dtype=float)
     >>> csr = sparse.csr_array(dense)
     >>> edges = _edge_generator_from_csr(csr)

--- a/src/_skimage2/io/collection.py
+++ b/src/_skimage2/io/collection.py
@@ -178,13 +178,15 @@ class ImageCollection:
 
     Examples
     --------
+    >>> from pathlib import Path
     >>> import imageio.v3 as iio3
     >>> import _skimage2.io as io
+    >>> from _skimage2 import data
 
     # Where your images are located
-    >>> data_dir = os.path.join(os.path.dirname(__file__), '../data')
+    >>> data_dir = Path(data.__file__).parent
 
-    >>> coll = io.ImageCollection(data_dir + '/chess*.png')
+    >>> coll = io.ImageCollection(str(data_dir / 'chess*.png'))
     >>> len(coll)
     2
     >>> coll[0].shape
@@ -198,10 +200,10 @@ class ImageCollection:
     ...     def __call__ (self, index):
     ...         return iio3.imread(self.f, index=index)
     ...
-    >>> filename = data_dir + '/no_time_for_that_tiny.gif'
+    >>> filename = data_dir / 'no_time_for_that_tiny.gif'
     >>> ic = io.ImageCollection(range(24), load_func=MultiReader(filename))
-    >>> len(image_col)
-    23
+    >>> len(ic)
+    24
     >>> isinstance(ic[0], np.ndarray)
     True
     """
@@ -470,10 +472,12 @@ class MultiImage(ImageCollection):
 
     Examples
     --------
-    # Where your images are located
-    >>> data_dir = os.path.join(os.path.dirname(__file__), '../data')
+    >>> from pathlib import Path
+    >>> from _skimage2 import data
+    >>> from _skimage2.io import ImageCollection
+    >>> data_dir = Path(data.__file__).parent
 
-    >>> multipage_tiff = data_dir + '/multipage.tif'
+    >>> multipage_tiff = str(data_dir / 'multipage.tif')
     >>> multi_img = MultiImage(multipage_tiff)
     >>> len(multi_img)  # multi_img contains one element
     1

--- a/src/_skimage2/measure/_moments.py
+++ b/src/_skimage2/measure/_moments.py
@@ -82,6 +82,7 @@ def moments_coords_central(coords, center=None, order=3):
 
     Examples
     --------
+    >>> from _skimage2.measure import moments_coords
     >>> coords = np.array([[row, col]
     ...                    for row in range(13, 17)
     ...                    for col in range(14, 18)])
@@ -237,6 +238,7 @@ def moments_central(image, center=None, order=3, *, spacing=None, **kwargs):
 
     Examples
     --------
+    >>> from _skimage2.measure import moments
     >>> image = np.zeros((20, 20), dtype=np.float64)
     >>> image[13:17, 13:17] = 1
     >>> M = moments(image)
@@ -311,6 +313,7 @@ def moments_normalized(mu, order=3, spacing=None):
 
     Examples
     --------
+    >>> from _skimage2.measure import moments, moments_central
     >>> image = np.zeros((20, 20), dtype=np.float64)
     >>> image[13:17, 13:17] = 1
     >>> m = moments(image)
@@ -370,6 +373,7 @@ def moments_hu(nu):
 
     Examples
     --------
+    >>> from _skimage2.measure import moments_central, moments_normalized
     >>> image = np.zeros((20, 20), dtype=np.float64)
     >>> image[13:17, 13:17] = 0.5
     >>> image[10:12, 10:12] = 1

--- a/src/_skimage2/measure/_regionprops.py
+++ b/src/_skimage2/measure/_regionprops.py
@@ -895,7 +895,7 @@ def _props_to_dict(regions, properties=('label', 'bbox'), separator='-'):
     >>> from _skimage2 import data, util, measure
     >>> image = data.coins()
     >>> label_image = measure.label(image > 110, connectivity=image.ndim)
-    >>> proplist = regionprops(label_image, image)
+    >>> proplist = measure.regionprops(label_image, image)
     >>> props = _props_to_dict(proplist, properties=['label', 'inertia_tensor',
     ...                                              'inertia_tensor_eigvals'])
     >>> props  # doctest: +ELLIPSIS +SKIP

--- a/src/_skimage2/measure/fit.py
+++ b/src/_skimage2/measure/fit.py
@@ -1309,6 +1309,7 @@ def ransac(
 
     Generate ellipse data without tilt and add noise:
 
+    >>> from _skimage2.measure import EllipseModel
     >>> t = np.linspace(0, 2 * np.pi, 50)
     >>> xc, yc = 20, 30
     >>> a, b = 5, 10

--- a/src/_skimage2/morphology/_max_tree.py
+++ b/src/_skimage2/morphology/_max_tree.py
@@ -467,6 +467,8 @@ def area_closing(
     If a max-tree representation (parent and tree_traverser) are given to the
     function, they must be calculated from the inverted image for this
     function, i.e.:
+    >>> from _skimage2.morphology import diameter_closing, max_tree
+    >>> from _skimage2.util import invert
     >>> P, S = max_tree(invert(f))
     >>> closed = diameter_closing(f, 3, parent=P, tree_traverser=S)
     """
@@ -580,6 +582,8 @@ def diameter_closing(
     If a max-tree representation (parent and tree_traverser) are given to the
     function, they must be calculated from the inverted image for this
     function, i.e.:
+    >>> from _skimage2.morphology import max_tree
+    >>> from _skimage2.util import invert
     >>> P, S = max_tree(invert(f))
     >>> closed = diameter_closing(f, 3, parent=P, tree_traverser=S)
     """

--- a/src/_skimage2/morphology/_skeletonize.py
+++ b/src/_skimage2/morphology/_skeletonize.py
@@ -140,6 +140,7 @@ def _skeletonize_zhang(image):
 
     Examples
     --------
+    >>> from _skimage2.morphology import skeletonize
     >>> X, Y = np.ogrid[0:9, 0:9]
     >>> ellipse = (1./3 * (X - 4)**2 + (Y - 4)**2 < 3**2).astype(bool)
     >>> ellipse.view(np.uint8)

--- a/src/_skimage2/restoration/_denoise.py
+++ b/src/_skimage2/restoration/_denoise.py
@@ -963,6 +963,7 @@ def denoise_wavelet(
     Examples
     --------
     >>> from _skimage2 import color, data
+    >>> from _skimage2.util import img_as_float
     >>> img = img_as_float(data.astronaut())
     >>> img = color.rgb2gray(img)
     >>> rng = np.random.default_rng()

--- a/src/_skimage2/restoration/uft.py
+++ b/src/_skimage2/restoration/uft.py
@@ -159,6 +159,7 @@ def uirfftn(inarray, dim=None, shape=None):
 
     Examples
     --------
+    >>> from _skimage2.restoration.uft import urfftn
     >>> input = np.ones((5, 5, 5))
     >>> output = uirfftn(urfftn(input), shape=input.shape)
     >>> np.allclose(input, output)
@@ -297,6 +298,7 @@ def uirfft2(inarray, shape=None):
 
     Examples
     --------
+    >>> from _skimage2.restoration.uft import uirfftn, urfftn
     >>> input = np.ones((10, 128, 128))
     >>> output = uirfftn(urfftn(input), shape=input.shape)
     >>> np.allclose(input, output)
@@ -326,6 +328,7 @@ def image_quad_norm(inarray):
 
     Examples
     --------
+    >>> from _skimage2.restoration.uft import ufft2, urfft2
     >>> input = np.ones((5, 5))
     >>> image_quad_norm(ufft2(input)) == np.sum(np.abs(input)**2)
     True
@@ -433,6 +436,7 @@ def laplacian(ndim, shape, is_real=True):
 
     Examples
     --------
+    >>> from _skimage2.restoration.uft import ir2tf
     >>> tf, ir = laplacian(2, (32, 32))
     >>> np.all(ir == np.array([[0, -1, 0], [-1, 4, -1], [0, -1, 0]]))
     True

--- a/src/_skimage2/transform/finite_radon_transform.py
+++ b/src/_skimage2/transform/finite_radon_transform.py
@@ -98,6 +98,7 @@ def ifrt2(a):
 
     Apply the Finite Radon Transform:
 
+    >>> from _skimage2.transform import frt2
     >>> f = frt2(img)
 
     Apply the Inverse Finite Radon Transform to recover the input

--- a/src/_skimage2/transform/integral.py
+++ b/src/_skimage2/transform/integral.py
@@ -76,6 +76,7 @@ def integrate(ii, start, end):
 
     Examples
     --------
+    >>> from _skimage2.transform import integral_image
     >>> arr = np.ones((5, 6), dtype=float)
     >>> ii = integral_image(arr)
     >>> integrate(ii, (1, 0), (1, 2))  # sum from (1, 0) to (1, 2)


### PR DESCRIPTION
Only implicitly use own callable, and `np`, in doctests, import
everything else explicitly.

This implements the rule that doctests should always explicitly import stuff
that they use, except the function / method being tested, and `np`.
