### PR TITLE
[codex] Clarify the top-hat morphology example

### DIFF
--- a/doc/examples/filters/plot_tophat.py
+++ b/doc/examples/filters/plot_tophat.py
@@ -4,10 +4,10 @@ Removing small objects in grayscale images with a top hat filter
 ================================================================
 
 This example shows how to remove small objects from grayscale images.
-The top-hat transform [1]_ is an operation that extracts small elements and
-details from given images. Here we use a white top-hat transform, which is
-defined as the difference between the input image and its
-(mathematical morphology) opening.
+The top-hat transform [1]_ extracts small elements and details from an image.
+Here, the white top-hat transform extracts bright structures smaller than the
+footprint. Morphological opening produces the complementary result, with these
+bright structures removed.
 
 .. [1] https://en.wikipedia.org/wiki/Top-hat_transform
 
@@ -21,14 +21,15 @@ from skimage import color, morphology
 image = color.rgb2gray(data.hubble_deep_field())[:500, :500]
 
 footprint = morphology.disk(1)
-res = morphology.white_tophat(image, footprint)
+white_tophat = morphology.white_tophat(image, footprint)
+opened = morphology.opening(image, footprint)
 
 fig, ax = plt.subplots(ncols=3, figsize=(20, 8))
 ax[0].set_title('Original')
 ax[0].imshow(image, cmap='gray')
-ax[1].set_title('White tophat')
-ax[1].imshow(res, cmap='gray')
-ax[2].set_title('Complementary')
-ax[2].imshow(image - res, cmap='gray')
+ax[1].set_title('White top-hat')
+ax[1].imshow(white_tophat, cmap='gray')
+ax[2].set_title('Morphological opening')
+ax[2].imshow(opened, cmap='gray')
 
 plt.show()


### PR DESCRIPTION
Fixes #7920

## Summary

- Clarify that the white top-hat extracts bright structures smaller than the footprint.
- Compute and display `morphology.opening` explicitly.
- Rename the example panels to describe the displayed operations directly.

## Motivation

The previous example derived the opening indirectly as `image - white_tophat`, which made the intended operation harder to recognize. Calling `morphology.opening` directly keeps the example aligned with the operation being explained.

## User impact

Readers can now distinguish the structures extracted by the white top-hat from the image produced by morphological opening without having to infer the complementary operation.

## Validation

- `python -m compileall -q doc/examples/filters/plot_tophat.py`
- `MPLBACKEND=Agg python doc/examples/filters/plot_tophat.py`
- `git diff --check`

## AI usage

OpenAI Codex assisted with implementation and local verification. The final diff still needs the author's line-by-line review before this draft is marked ready for review.
