### PR TITLE
[codex] Use OO interface in Radon gallery example

### DIFF
--- a/doc/examples/transform/plot_radon_transform.py
+++ b/doc/examples/transform/plot_radon_transform.py
@@ -108,13 +108,14 @@ from skimage.transform.radon_transform import _get_fourier_filter
 
 filters = ['ramp', 'shepp-logan', 'cosine', 'hamming', 'hann']
 
+fig, ax = plt.subplots()
 for ix, f in enumerate(filters):
     response = _get_fourier_filter(2000, f)
-    plt.plot(response, label=f)
+    ax.plot(response, label=f)
 
-plt.xlim([0, 1000])
-plt.xlabel('frequency')
-plt.legend()
+ax.set_xlim([0, 1000])
+ax.set_xlabel('frequency')
+ax.legend()
 plt.show()
 
 ######################################################################


### PR DESCRIPTION
Addresses part of #7330.

## Summary

- Create an explicit Matplotlib figure and axes for the Fourier-filter response plot.
- Replace the remaining stateful `pyplot` plotting calls in that section with axes methods.

## Motivation

The Radon transform gallery example mixed Matplotlib's object-oriented and stateful interfaces. This small change makes the filter-response section consistent with the rest of the example and with the gallery style requested in #7330.

## User impact

The rendered curves, limits, label, and legend are unchanged; the example code now demonstrates one consistent Matplotlib interface.

## Validation

- `python -m compileall -q doc/examples/transform/plot_radon_transform.py`
- `MPLBACKEND=Agg python doc/examples/transform/plot_radon_transform.py`
- `git diff origin/main...HEAD --check`

The complete example ran successfully, including the Radon transform, filtered back projection, and both SART iterations.

## AI usage

OpenAI Codex assisted with the implementation and local verification. The change was reviewed line by line and is limited to equivalent Matplotlib API calls.
