### PR TITLE
changed the code to utilise fast code path for order=0

### DIFF
--- a/src/_skimage2/transform/_warps.py
+++ b/src/_skimage2/transform/_warps.py
@@ -936,7 +936,8 @@ def warp(
 
     order = _validate_interpolation_order(image.dtype, order)
 
-    if order > 0:
+    image_dtype = image.dtype
+    if order >= 0:
         image = convert_to_float(image, preserve_range)
         if image.dtype == np.float16:
             image = image.astype(np.float32)
@@ -963,7 +964,7 @@ def warp(
             "to use bi-linear or bi-cubic interpolation instead."
         )
 
-    if order in (1, 3) and not map_args:
+    if order in (0, 1, 3) and not map_args:
         # use fast Cython version for specific interpolation orders and input
 
         matrix = None
@@ -1054,6 +1055,9 @@ def warp(
         )
 
     _clip_warp_output(image, warped, mode, cval, clip)
+
+    if order == 0:
+        warped = warped.astype(image_dtype)
 
     return warped
 


### PR DESCRIPTION
fixes #7273. I put in the changes recommended by @stefanv 

also had to add in a condition at the last of the code 

```python
if order == 0:
    warped = warped.astype(image_dtype)
```
This is as before the code for order = 0 was going to map_coordinates which preserved the orginal image dytpe I had to add in this change to preserve the original image dtype otherwise would fail the test  -  test_order_0_warp_dtype  
