### PR TITLE
Li Threshold: don't offset positive intensities

### DIFF
--- a/src/_skimage2/filters/thresholding.py
+++ b/src/_skimage2/filters/thresholding.py
@@ -724,12 +724,13 @@ def threshold_li(image, *, tolerance=None, initial_guess=None, iter_callback=Non
         t_next = initial_guess(image)
     elif np.isscalar(initial_guess):  # convert to new, positive image range
         t_next = initial_guess - float(image_min)
-        image_max = np.max(image) + image_min
-        if not 0 < t_next < np.max(image):
+        actual_min = np.min(image) + image_min
+        actual_max = np.max(image) + image_min
+        if not np.min(image) < t_next < np.max(image):
             msg = (
                 f'The initial guess for threshold_li must be within the '
                 f'range of the image. Got {initial_guess} for image min '
-                f'{image_min} and max {image_max}.'
+                f'{actual_min} and max {actual_max}.'
             )
             raise ValueError(msg)
         t_next = image.dtype.type(t_next)

--- a/src/_skimage2/filters/thresholding.py
+++ b/src/_skimage2/filters/thresholding.py
@@ -706,8 +706,11 @@ def threshold_li(image, *, tolerance=None, initial_guess=None, iter_callback=Non
     if image.size == 0:
         return 0.0
 
-    # Li's algorithm requires positive image (because of log(mean))
-    image_min = np.min(image)
+    # Li's algorithm requires positive image (because of log(mean)).
+    # But the the constraint on which the algorithm is based depends on
+    # actual means of the thresholded image.
+    # Hense, keep original intensities when possible.
+    image_min = min(0, np.min(image))
     image -= image_min
     if image.dtype.kind in 'iu':
         tolerance = tolerance or 0.5

--- a/tests/skimage/filters/test_thresholding.py
+++ b/tests/skimage/filters/test_thresholding.py
@@ -383,7 +383,7 @@ def test_li_astro_image_no_zeros():
     image = util.img_as_ubyte(data.astronaut())
     image[image < 50] = 50
     threshold = threshold_li(image)
-    ce_actual = _cross_entropy(image, threshold, np.max(image))
+    ce_actual = _cross_entropy(image, threshold)
     assert 112 < threshold < 113
     assert ce_actual < _cross_entropy(image, threshold + 1)
     assert ce_actual < _cross_entropy(image, threshold - 1)

--- a/tests/skimage/filters/test_thresholding.py
+++ b/tests/skimage/filters/test_thresholding.py
@@ -377,6 +377,18 @@ def test_li_astro_image():
     assert ce_actual < _cross_entropy(image, threshold - 1)
 
 
+def test_li_astro_image_no_zeros():
+    # threshold with the minimal cross-entropy depends
+    # non-linearly on means of the thresholded image.
+    image = util.img_as_ubyte(data.astronaut())
+    image[image < 50] = 50
+    threshold = threshold_li(image)
+    ce_actual = _cross_entropy(image, threshold, np.max(image))
+    assert 112 < threshold < 113
+    assert ce_actual < _cross_entropy(image, threshold + 1)
+    assert ce_actual < _cross_entropy(image, threshold - 1)
+
+
 def test_li_nan_image():
     image = np.full((5, 5), np.nan)
     assert np.isnan(threshold_li(image))

--- a/tests/skimage2/filters/test_thresholding.py
+++ b/tests/skimage2/filters/test_thresholding.py
@@ -383,7 +383,7 @@ def test_li_astro_image_no_zeros():
     image = util.img_as_ubyte(data.astronaut())
     image[image < 50] = 50
     threshold = threshold_li(image)
-    ce_actual = _cross_entropy(image, threshold, np.max(image))
+    ce_actual = _cross_entropy(image, threshold)
     assert 112 < threshold < 113
     assert ce_actual < _cross_entropy(image, threshold + 1)
     assert ce_actual < _cross_entropy(image, threshold - 1)

--- a/tests/skimage2/filters/test_thresholding.py
+++ b/tests/skimage2/filters/test_thresholding.py
@@ -377,6 +377,18 @@ def test_li_astro_image():
     assert ce_actual < _cross_entropy(image, threshold - 1)
 
 
+def test_li_astro_image_no_zeros():
+    # threshold with the minimal cross-entropy depends
+    # non-linearly on means of the thresholded image.
+    image = util.img_as_ubyte(data.astronaut())
+    image[image < 50] = 50
+    threshold = threshold_li(image)
+    ce_actual = _cross_entropy(image, threshold, np.max(image))
+    assert 112 < threshold < 113
+    assert ce_actual < _cross_entropy(image, threshold + 1)
+    assert ce_actual < _cross_entropy(image, threshold - 1)
+
+
 def test_li_nan_image():
     image = np.full((5, 5), np.nan)
     assert np.isnan(threshold_li(image))


### PR DESCRIPTION
Threshold with the minimal cross-entropy depends on actual thresholded image means. But the means will differ if one offsets image intensities towards zero, which led to significantly inaccurate return value. This can be shown with the provided test.

Since it's still required to handle negative values case, I've ported its handling as it is done in the ITK LiThresholdCalculator. 