### PR TITLE
Ensure `spin docs --clean` also wipes `doc/source/api2`

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -23,7 +23,6 @@ def docs(*, parent_callback, install_deps, **kwargs):
     # `spin.cmds.meson.docs`. So we provide our own `clean_dirs`
     kwargs["clean_dirs"] = kwargs.get("clean_dirs", []) + [
         "./doc/build/",
-        "./doc/build/",
         "./doc/source/api/",
         "./doc/source/api2/",
         "./doc/source/auto_examples/",

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -19,6 +19,17 @@ def docs(*, parent_callback, install_deps, **kwargs):
     if install_deps:
         spin.util.run(['pip', 'install', '-q', '-r', 'requirements/docs.txt'])
 
+    # `doc/source/api2/` is not removed/coverd by `--clean` flag with default
+    # `spin.cmds.meson.docs`. So we provide our own `clean_dirs`
+    kwargs["clean_dirs"] = kwargs.get("clean_dirs", []) + [
+        "./doc/build/",
+        "./doc/build/",
+        "./doc/source/api/",
+        "./doc/source/api2/",
+        "./doc/source/auto_examples/",
+        "./doc/source/jupyterlite_contents/",
+    ]
+
     parent_callback(**kwargs)
 
 

--- a/src/_skimage2/data/_fetchers.py
+++ b/src/_skimage2/data/_fetchers.py
@@ -28,17 +28,21 @@ except ModuleNotFoundError:
     def file_hash(fname, alg="sha256"):
         """
         Calculate the hash of a given file.
+
         Useful for checking if a file has changed or been corrupted.
+
         Parameters
         ----------
         fname : str
             The name of the file.
         alg : str
             The type of the hashing algorithm
+
         Returns
         -------
         hash : str
             The hash of the file.
+
         Examples
         --------
         >>> fname = "test-file-for-hash.txt"
@@ -46,6 +50,7 @@ except ModuleNotFoundError:
         ...     __ = f.write("content of the file")
         >>> print(file_hash(fname))
         0fc74468e6a9a829f103d069aeb2bb4f8646bad58bf146bb0e3379b759ec4a00
+
         >>> import os
         >>> os.remove(fname)
         """


### PR DESCRIPTION
Relatively simple fix so that `spin docs --clean` works as intended again. This really tripped me for a minute when working on #8244 because I couldn't figure out why apidoc was still picking up functions I removed.

Also included a small docstring fix that's not really related but also caused noisy sphinx warning while debugging.

@stefanv you might want to check if I fixed this in the best way. 

### Release note (optional)

<!-- See https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes -->

```release-note
...
```
