### PR TITLE
DOC: Complete hsv_value docstring

### DIFF
--- a/src/_skimage2/color/adapt_rgb.py
+++ b/src/_skimage2/color/adapt_rgb.py
@@ -46,16 +46,26 @@ def adapt_rgb(apply_to_rgb):
 
 
 def hsv_value(image_filter, image, *args, **kwargs):
-    """Return color image by applying `image_filter` on HSV-value of `image`.
+    """Return color image by applying `image_filter` to the HSV value channel.
 
     Note that this function is intended for use with `adapt_rgb`.
 
     Parameters
     ----------
-    image_filter : function
-        Function that filters a gray-scale image.
+    image_filter : callable
+        Function that filters a gray-scale image. Additional positional and
+        keyword arguments are forwarded to this function.
     image : array
         Input image. Note that RGBA images are treated as RGB.
+    *args : tuple
+        Additional positional arguments passed to `image_filter`.
+    **kwargs : dict
+        Additional keyword arguments passed to `image_filter`.
+
+    Returns
+    -------
+    filtered : ndarray
+        Color image with the filtered HSV value channel.
     """
     # Slice the first three channels so that we remove any alpha channels.
     hsv = color.rgb2hsv(image[:, :, :3])


### PR DESCRIPTION
## Summary

- Completes the `hsv_value` docstring.
- Documents the forwarded `*args` and `**kwargs`.
- Adds a `Returns` section describing the filtered color image.

Addresses #7270.

## Details

`hsv_value` already forwards extra positional and keyword arguments to the
supplied image filter and returns an RGB color image. These details were missing
from its docstring. This change documents the existing behavior only; it does
not change the implementation or public API.

## Validation

- `git diff --check`
- Parsed the edited module with `ast`
- Compiled the edited source with `compile()`

`spin`, `ruff`, and `docstub` are not installed in the configured development
environment, so those checks were not run.

## AI assistance

This PR was prepared with assistance from OpenAI Codex. I reviewed every
changed line and verified the scope and validation results above.
