### PR TITLE
regionprops.py documentation clarification

### DIFF
--- a/src/_skimage2/measure/_regionprops.py
+++ b/src/_skimage2/measure/_regionprops.py
@@ -1288,8 +1288,8 @@ def regionprops(
     **image_filled** : (H, J) ndarray
         Binary region image with filled holes sliced by bounding box.
     **image_intensity** : (H, J) ndarray
-         Intensity image sliced by the bounding box and masked by the region image.
-         Pixels outside the region are set to 0.
+        Intensity image sliced by the bounding box and masked by the region image.
+        Pixels outside the region are set to 0.
     **inertia_tensor** : ndarray
         Inertia tensor of the region for the rotation around its mass.
     **inertia_tensor_eigvals** : tuple

--- a/src/_skimage2/measure/_regionprops.py
+++ b/src/_skimage2/measure/_regionprops.py
@@ -1288,7 +1288,7 @@ def regionprops(
     **image_filled** : (H, J) ndarray
         Binary region image with filled holes sliced by bounding box.
     **image_intensity** : (H, J) ndarray
-        Intensity image sliced by the bounding box and masked by the region image.
+        Intensity image sliced by the bounding box and masked to the region.
         Pixels outside the region are set to 0.
     **inertia_tensor** : ndarray
         Inertia tensor of the region for the rotation around its mass.

--- a/src/_skimage2/measure/_regionprops.py
+++ b/src/_skimage2/measure/_regionprops.py
@@ -1288,7 +1288,8 @@ def regionprops(
     **image_filled** : (H, J) ndarray
         Binary region image with filled holes sliced by bounding box.
     **image_intensity** : (H, J) ndarray
-        Intensity image sliced by bounding box.
+         Intensity image sliced by the bounding box and masked by the region image.
+         Pixels outside the region are set to 0.
     **inertia_tensor** : ndarray
         Inertia tensor of the region for the rotation around its mass.
     **inertia_tensor_eigvals** : tuple

--- a/src/_skimage2/measure/_regionprops.py
+++ b/src/_skimage2/measure/_regionprops.py
@@ -1289,7 +1289,6 @@ def regionprops(
         Binary region image with filled holes sliced by bounding box.
     **image_intensity** : (H, J) ndarray
         Intensity image sliced by the bounding box and masked to the region.
-        Pixels outside the region are set to 0.
     **inertia_tensor** : ndarray
         Inertia tensor of the region for the rotation around its mass.
     **inertia_tensor_eigvals** : tuple


### PR DESCRIPTION
regionprops.py documentation clarification.

Current documentation says that ''image intensity'' is computed as the intesity image sliced by the bounding box. What actually happens in the code is that the return values is also masked by the region image. This means that pixels inside the box, but outside the region, have value 0 after the masking operation. In my understanding this was made intentionally made in order to distinguish region groups from arbitrary rectangular crops. However documentation didnt make this clear.

Closes gh-7840.
