### PR TITLE
Use object-oriented matplotlib style in camera example in documentation

### DIFF
--- a/doc/examples/numpy_operations/plot_camera_numpy.py
+++ b/doc/examples/numpy_operations/plot_camera_numpy.py
@@ -23,7 +23,7 @@ X, Y = np.ogrid[:l_x, :l_y]
 outer_disk_mask = (X - l_x / 2) ** 2 + (Y - l_y / 2) ** 2 > (l_x / 2) ** 2
 camera[outer_disk_mask] = 0
 
-plt.figure(figsize=(4, 4))
-plt.imshow(camera, cmap='gray')
-plt.axis('off')
+fig, ax = plt.subplots(figsize=(4, 4))
+ax.imshow(camera, cmap='gray')
+ax.axis('off')
 plt.show()


### PR DESCRIPTION
Update one gallery example to use Matplotlib's object-oriented API.

This changes `doc/examples/numpy_operations/plot_camera_numpy.py` so that the image is drawn using object-oriented matplotlib stylein stead of pyplot-level calls.

This is part of #7330.

