### PR TITLE
Add mask parameter to threshold_otsu

### DIFF
--- a/src/_skimage2/filters/thresholding.py
+++ b/src/_skimage2/filters/thresholding.py
@@ -330,7 +330,7 @@ def _validate_image_histogram(image, hist, nbins=None, normalize=False):
     return counts.astype('float32', copy=False), bin_centers
 
 
-def threshold_otsu(image=None, nbins=256, *, hist=None):
+def threshold_otsu(image=None, nbins=256, *, hist=None, mask=None):
     """Return threshold value based on Otsu's method.
 
     Either image or hist must be provided. If hist is provided, the actual
@@ -347,7 +347,11 @@ def threshold_otsu(image=None, nbins=256, *, hist=None):
         Histogram from which to determine the threshold, and optionally a
         corresponding array of bin center intensities. If no hist provided,
         this function will compute it from the image.
-
+    mask : ndarray of bools, optional
+        Array of the same shape as `image`. Only pixels where `mask` is
+        ``True`` are used to compute the threshold; pixels outside the mask
+        are excluded from the histogram entirely. Mutually exclusive with
+        `hist`.
 
     Returns
     -------
@@ -376,6 +380,16 @@ def threshold_otsu(image=None, nbins=256, *, hist=None):
             f'grayscale images; image shape {image.shape} looks like '
             f'that of an RGB image.'
         )
+
+    if mask is not None:
+        if hist is not None:
+            raise ValueError('mask and hist cannot both be provided.')
+        if image is None:
+            raise ValueError('mask requires image to be provided.')
+        mask = np.asarray(mask, dtype=bool)
+        if mask.shape != image.shape:
+            raise ValueError('image and mask must have the same shape.')
+        image = image[mask]
 
     # Check if the image has more than one intensity value; if not, return that
     # value

--- a/src/_skimage2/filters/thresholding.py
+++ b/src/_skimage2/filters/thresholding.py
@@ -390,6 +390,10 @@ def threshold_otsu(image=None, nbins=256, *, hist=None, mask=None):
         if mask.shape != image.shape:
             raise ValueError('image and mask must have the same shape.')
         image = image[mask]
+        if image.size == 0:
+            raise ValueError(
+                'mask selects no pixels; it must contain at least one True value.'
+            )
 
     # Check if the image has more than one intensity value; if not, return that
     # value

--- a/tests/skimage/filters/test_thresholding.py
+++ b/tests/skimage/filters/test_thresholding.py
@@ -340,6 +340,46 @@ def test_otsu_one_color_image_3d():
     assert threshold_otsu(img) == 1
 
 
+def test_otsu_masked_image():
+    image = np.zeros((10, 10), dtype=np.uint8)
+    image[:, 5:] = 200
+    image[:4, :] = 50  # artefact region that should be excluded by the mask
+    mask = np.ones((10, 10), dtype=bool)
+    mask[:4, :] = False
+
+    assert threshold_otsu(image, mask=mask) == threshold_otsu(image[mask])
+    assert threshold_otsu(image, mask=mask) != threshold_otsu(image)
+
+
+def test_otsu_masked_uniform_region():
+    image = np.zeros((10, 10), dtype=np.uint8)
+    image[:, 5:] = 200
+    mask = np.zeros((10, 10), dtype=bool)
+    mask[:, :5] = True  # masked region is uniformly 0, full image is not
+
+    assert threshold_otsu(image, mask=mask) == 0
+
+
+def test_otsu_mask_and_hist_raises():
+    image = np.ones((10, 10), dtype=np.uint8)
+    mask = np.ones((10, 10), dtype=bool)
+    with pytest.raises(ValueError):
+        threshold_otsu(image, hist=np.bincount(image.ravel()), mask=mask)
+
+
+def test_otsu_mask_shape_mismatch_raises():
+    image = np.ones((10, 10), dtype=np.uint8)
+    mask = np.ones((5, 5), dtype=bool)
+    with pytest.raises(ValueError):
+        threshold_otsu(image, mask=mask)
+
+
+def test_otsu_mask_without_image_raises():
+    mask = np.ones((10, 10), dtype=bool)
+    with pytest.raises(ValueError):
+        threshold_otsu(mask=mask)
+
+
 def test_li_camera_image():
     image = util.img_as_ubyte(data.camera())
     threshold = threshold_li(image)

--- a/tests/skimage/filters/test_thresholding.py
+++ b/tests/skimage/filters/test_thresholding.py
@@ -380,6 +380,13 @@ def test_otsu_mask_without_image_raises():
         threshold_otsu(mask=mask)
 
 
+def test_otsu_all_false_mask_raises():
+    image = np.ones((10, 10), dtype=np.uint8)
+    mask = np.zeros((10, 10), dtype=bool)
+    with pytest.raises(ValueError):
+        threshold_otsu(image, mask=mask)
+
+
 def test_li_camera_image():
     image = util.img_as_ubyte(data.camera())
     threshold = threshold_li(image)

--- a/tests/skimage2/filters/test_thresholding.py
+++ b/tests/skimage2/filters/test_thresholding.py
@@ -340,6 +340,46 @@ def test_otsu_one_color_image_3d():
     assert threshold_otsu(img) == 1
 
 
+def test_otsu_masked_image():
+    image = np.zeros((10, 10), dtype=np.uint8)
+    image[:, 5:] = 200
+    image[:4, :] = 50  # artefact region that should be excluded by the mask
+    mask = np.ones((10, 10), dtype=bool)
+    mask[:4, :] = False
+
+    assert threshold_otsu(image, mask=mask) == threshold_otsu(image[mask])
+    assert threshold_otsu(image, mask=mask) != threshold_otsu(image)
+
+
+def test_otsu_masked_uniform_region():
+    image = np.zeros((10, 10), dtype=np.uint8)
+    image[:, 5:] = 200
+    mask = np.zeros((10, 10), dtype=bool)
+    mask[:, :5] = True  # masked region is uniformly 0, full image is not
+
+    assert threshold_otsu(image, mask=mask) == 0
+
+
+def test_otsu_mask_and_hist_raises():
+    image = np.ones((10, 10), dtype=np.uint8)
+    mask = np.ones((10, 10), dtype=bool)
+    with pytest.raises(ValueError):
+        threshold_otsu(image, hist=np.bincount(image.ravel()), mask=mask)
+
+
+def test_otsu_mask_shape_mismatch_raises():
+    image = np.ones((10, 10), dtype=np.uint8)
+    mask = np.ones((5, 5), dtype=bool)
+    with pytest.raises(ValueError):
+        threshold_otsu(image, mask=mask)
+
+
+def test_otsu_mask_without_image_raises():
+    mask = np.ones((10, 10), dtype=bool)
+    with pytest.raises(ValueError):
+        threshold_otsu(mask=mask)
+
+
 def test_li_camera_image():
     image = util.img_as_ubyte(data.camera())
     threshold = threshold_li(image)

--- a/tests/skimage2/filters/test_thresholding.py
+++ b/tests/skimage2/filters/test_thresholding.py
@@ -380,6 +380,13 @@ def test_otsu_mask_without_image_raises():
         threshold_otsu(mask=mask)
 
 
+def test_otsu_all_false_mask_raises():
+    image = np.ones((10, 10), dtype=np.uint8)
+    mask = np.zeros((10, 10), dtype=bool)
+    with pytest.raises(ValueError):
+        threshold_otsu(image, mask=mask)
+
+
 def test_li_camera_image():
     image = util.img_as_ubyte(data.camera())
     threshold = threshold_li(image)


### PR DESCRIPTION
Closes #3604.

This adds an optional `mask` argument to `threshold_otsu`, keyword-only.
When you pass a mask, only the `True` pixels go into the Otsu
computation; the masked-out pixels are dropped from the histogram rather
than folded into the background. That is a small departure from the
original issue, which suggested treating them as background, but it keeps
the result identical to calling `threshold_otsu` on `image[mask]`, which
seemed like the least surprising behavior. It follows the same `mask`
convention as `exposure.equalize_hist` (#1109).

The function raises `ValueError` with a clear message in four cases: a
mask passed together with `hist` (which bypasses the image, so the mask
would do nothing), a mask passed without an image, a mask whose shape
does not match the image, and an all-False mask. That last case is the
second commit here: an empty selection used to fall through to a bare
`IndexError`, so it now raises a descriptive error instead.

Tests are in `tests/skimage/filters/test_thresholding.py` and the
mirrored `tests/skimage2/` copy: one checks a masked image against the
`threshold_otsu(image[mask])` baseline and that it differs from the
unmasked result, one checks a masked uniform region, and four cover the
`ValueError` paths above. The full thresholding suite passes and the new
lines are covered.

```release-note
Add a `mask` parameter to `skimage.filters.threshold_otsu`, which
restricts the threshold computation to pixels within the mask.
```
