### PR TITLE
Update footprint descriptions for grayscale functions

### DIFF
--- a/src/_skimage2/morphology/_grayscale_operators.py
+++ b/src/_skimage2/morphology/_grayscale_operators.py
@@ -115,7 +115,8 @@ def erosion(image, footprint=None, *, out=None, mode="ignore", cval=0.0):
     image : ndarray
         Input image.
     footprint : ndarray or tuple, optional
-        The neighborhood expressed as a 2-D array of 1's and 0's.
+        The footprint that defines the active neighborhood. Nonzero elements
+        are considered part of the neighborhood.
         If None, use a cross-shaped footprint (so-called *1-connectivity*).
         The footprint can also be provided as a sequence of smaller footprints
         as described in the notes below. See _Notes_ for more.
@@ -216,7 +217,8 @@ def dilation(image, footprint=None, *, out=None, mode="ignore", cval=0.0):
     image : ndarray
         Input image.
     footprint : ndarray or tuple, optional
-        The neighborhood expressed as a 2-D array of 1's and 0's.
+        The footprint that defines the active neighborhood. Nonzero elements
+        are considered part of the neighborhood.
         If None, use a cross-shaped footprint (so-called *1-connectivity*).
         The footprint can also be provided as a sequence of smaller footprints
         as described in the notes below. See _Notes_ for more.
@@ -318,7 +320,8 @@ def opening(image, footprint=None, *, out=None, mode="ignore", cval=0.0):
     image : ndarray
         Input image.
     footprint : ndarray or tuple, optional
-        The neighborhood expressed as a 2-D array of 1's and 0's.
+        The footprint that defines the active neighborhood. Nonzero elements
+        are considered part of the neighborhood.
         If None, use a cross-shaped footprint (so-called *1-connectivity*).
         The footprint can also be provided as a sequence of smaller footprints
         as described in the notes below. See _Notes_ for more.
@@ -397,7 +400,8 @@ def closing(image, footprint=None, *, out=None, mode="ignore", cval=0.0):
     image : ndarray
         Input image.
     footprint : ndarray or tuple, optional
-        The neighborhood expressed as a 2-D array of 1's and 0's.
+        The footprint that defines the active neighborhood. Nonzero elements
+        are considered part of the neighborhood.
         If None, use a cross-shaped footprint (so-called *1-connectivity*).
         The footprint can also be provided as a sequence of smaller footprints
         as described in the notes below. See _Notes_ for more.
@@ -475,7 +479,8 @@ def white_tophat(image, footprint=None, *, out=None, mode="ignore", cval=0.0):
     image : ndarray
         Input image.
     footprint : ndarray or tuple, optional
-        The neighborhood expressed as a 2-D array of 1's and 0's.
+        The footprint that defines the active neighborhood. Nonzero elements
+        are considered part of the neighborhood.
         If None, use a cross-shaped footprint (so-called *1-connectivity*).
         The footprint can also be provided as a sequence of smaller footprints
         as described in the notes below. See _Notes_ for more.
@@ -570,7 +575,8 @@ def black_tophat(image, footprint=None, *, out=None, mode="ignore", cval=0.0):
     image : ndarray
         Input image.
     footprint : ndarray or tuple, optional
-        The neighborhood expressed as a 2-D array of 1's and 0's.
+        The footprint that defines the active neighborhood. Nonzero elements
+        are considered part of the neighborhood.
         If None, use a cross-shaped footprint (so-called *1-connectivity*).
         The footprint can also be provided as a sequence of smaller footprints
         as described in the notes below. See _Notes_ for more.


### PR DESCRIPTION
<!--
Please see the Contribution Guide:
https://scikit-image.org/docs/dev/development/contribute.html
For newcomers: this document has a checklist of what we expect in a PR.

Also please note our AI policy:
https://scikit-image.org/docs/dev/development/contribute.html#ai-policy
-->

This PR updates the  footprint  parameter description for grayscale  functions.

The previous version described the footprint as a 2-D neighborhood, but these functions can operate on images with any number of dimensions. The new wording describes the footprint in terms of its nonzero elements instead.

This PR only updates documentation. No behavior is changed.

Closes gh-7700.

AI tool disclosure: I used ChatGPT/Codex to help understand the issue discussion and draft the wording for this documentation-only change. I reviewed the proposed change myself.
### Release note (optional)

<!-- See https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes -->

```release-note
Clarify the `footprint` parameter description for grayscale morphology functions.
...
```
