### PR TITLE
Fix _masked_phase_cross_correlation

### DIFF
--- a/src/_skimage2/registration/_masked_phase_cross_correlation.py
+++ b/src/_skimage2/registration/_masked_phase_cross_correlation.py
@@ -91,11 +91,7 @@ def _masked_phase_cross_correlation(
     center = np.mean(maxima, axis=0)
     shifts = center - np.array(reference_image.shape) + 1
 
-    # The mismatch in size will impact the center location of the
-    # cross-correlation
-    size_mismatch = np.array(moving_image.shape) - np.array(reference_image.shape)
-
-    return -shifts + (size_mismatch / 2)
+    return -shifts
 
 
 def cross_correlate_masked(

--- a/tests/skimage/registration/test_masked_phase_cross_correlation.py
+++ b/tests/skimage/registration/test_masked_phase_cross_correlation.py
@@ -101,7 +101,7 @@ def test_masked_registration_random_masks_non_equal_sizes():
         reference_mask=np.ones_like(ref_mask),
         moving_mask=np.ones_like(shifted_mask),
     )
-    assert_equal(measured_shift, -np.array(shift))
+    assert_equal(measured_shift, -np.array(shift) + np.array([64, 64]))
 
 
 def test_masked_registration_padfield_data(test_root_dir):

--- a/tests/skimage2/registration/test_masked_phase_cross_correlation.py
+++ b/tests/skimage2/registration/test_masked_phase_cross_correlation.py
@@ -101,7 +101,7 @@ def test_masked_registration_random_masks_non_equal_sizes():
         reference_mask=np.ones_like(ref_mask),
         moving_mask=np.ones_like(shifted_mask),
     )
-    assert_equal(measured_shift, -np.array(shift))
+    assert_equal(measured_shift, -np.array(shift) + np.array([64, 64]))
 
 
 def test_masked_registration_padfield_data(test_root_dir):


### PR DESCRIPTION
_masked_phase_cross_correlation returned wrong shifts value when reference image and moving image are not same size. 
It should return shifts value to register moving_image with reference_image - that means a coordinate on reference image to place the left top of moving image - , but it always returned shifts value that assumed moving image has same size as reference image like below.

```
>>> import numpy as np
>>> ref_image = np.zeros((50,50), dtype=np.uint8)
>>> ref_image[20:30, 20:30] = 255
>>> mov_image = ref_image[10:40, 10:40]
>>> ref_mask = np.ones(ref_image.shape, dtype=np.bool)
>>> mov_mask = np.ones(mov_image.shape, dtype=np.bool)
>>> from skimage.registration._masked_phase_cross_correlation import _masked_phase_cross_correlation
>>> shifts = _masked_phase_cross_correlation(ref_image, mov_image, reference_mask=ref_mask, moving_mask=mov_mask)
>>> shifts
array([0., 0.])    # should be array([10., 10.])
```


### Release note (optional)


```release-note
Fix _masked_phase_cross_correlation when images has differentsize.
```
