### PR TITLE
fix: correct typos in source and tests

### DIFF
--- a/src/_skimage2/filters/rank/generic.py
+++ b/src/_skimage2/filters/rank/generic.py
@@ -183,7 +183,7 @@ def _preprocess_input(
     for name, value in zip(("shift_x", "shift_y"), (shift_x, shift_y)):
         if np.dtype(type(value)) == bool:
             warn(
-                f"Paramter `{name}` is boolean and will be interpreted as int. "
+                f"Parameter `{name}` is boolean and will be interpreted as int. "
                 "This is not officially supported, use int instead.",
                 category=UserWarning,
                 stacklevel=4,

--- a/tests/skimage/metrics/test_structural_similarity.py
+++ b/tests/skimage/metrics/test_structural_similarity.py
@@ -252,7 +252,7 @@ def test_ssim_warns_about_data_range():
     regex = (
         r'Inputs have mismatched dtypes'
         # Warning is raised twice, in wrapper with this optional bit and in
-        # _skimage2 implmentation without this bit:
+        # _skimage2 implementation without this bit:
         r'(\. Setting data_range based on im1\.dtype\.)?'
     )
     with pytest.warns(UserWarning, match=regex):


### PR DESCRIPTION
- implmentation → implementation\n- Paramter → Parameter