### PR TITLE
docs: clarify scalar type consistency guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,6 +263,10 @@ expedited review and acceptance.
 - Use numpy data types instead of strings (`np.uint8` instead of
   `"uint8"`).
 
+- Return a consistent family of types. Do not mix native Python scalars and NumPy scalar types in the same return value.
+
+- Prefer the native Python `bool` type over NumPy `np.bool_` when the value is not part of an array dtype.
+
 - When documenting array parameters, use `image : ndarray of shape (M, N)`
   and then refer to `M` and `N` in the docstring, if necessary.
 


### PR DESCRIPTION
Fixes #8197

Add the missing scalar-type guidance to the stylistic guidelines: return values should not mix native and NumPy scalar types, and plain Python booleans should be preferred when an array dtype is not involved.