### PR TITLE
docs: explain hough line peak threshold behavior

### DIFF
--- a/src/_skimage2/transform/hough_transform.py
+++ b/src/_skimage2/transform/hough_transform.py
@@ -37,7 +37,10 @@ def hough_line_peaks(
         Minimum angle separating lines (maximum filter size for second
         dimension of hough space).
     threshold : float, optional
-        Minimum intensity of peaks. Default is `0.5 * max(hspace)`.
+        Minimum intensity of peaks. If `None`, the threshold is set to `0.5 * max(hspace)`. This
+        global threshold can exclude shorter but valid lines when a longer line produces a
+        strong peak. To keep more candidates, set an explicit lower threshold and use
+        `num_peaks`, `min_distance`, or `min_angle` to limit the results.
     num_peaks : int, optional
         Maximum number of peaks. When the number of peaks exceeds `num_peaks`,
         return `num_peaks` coordinates based on peak intensity.


### PR DESCRIPTION
Fixes #7766

Clarify that the default Hough-line peak threshold is a global half-maximum cutoff and can miss shorter lines. The docstring now suggests lowering the threshold explicitly and using the existing peak-spacing and count controls to limit candidates.