### PR TITLE
DOC clarify resize dimensionality and channel handling

### DIFF
--- a/src/_skimage2/transform/_warps.py
+++ b/src/_skimage2/transform/_warps.py
@@ -81,7 +81,7 @@ def resize(
 ):
     """Resize image to match a certain size.
 
-    Performs interpolation to up-size or down-size N-dimensional images. Note
+    Performs interpolation to up-size or down-size n-dimensional images. Note
     that anti-aliasing should be enabled when down-sizing images to avoid
     aliasing artifacts. For downsampling with an integer factor also see
     `skimage.transform.downscale_local_mean`.
@@ -243,7 +243,7 @@ def rescale(
 ):
     """Scale image by a certain factor.
 
-    Performs interpolation to up-scale or down-scale N-dimensional images.
+    Performs interpolation to up-scale or down-scale n-dimensional images.
     Note that anti-aliasing should be enabled when down-sizing images to avoid
     aliasing artifacts. For down-sampling with an integer factor also see
     `skimage.transform.downscale_local_mean`.
@@ -472,7 +472,7 @@ def rotate(
 
 
 def downscale_local_mean(image, factors, cval=0, clip=True):
-    """Down-sample N-dimensional image by local averaging.
+    """Down-sample n-dimensional image by local averaging.
 
     The image is padded with `cval` if it is not perfectly divisible by the
     integer factors.

--- a/src/_skimage2/transform/_warps.py
+++ b/src/_skimage2/transform/_warps.py
@@ -89,12 +89,14 @@ def resize(
     Parameters
     ----------
     image : ndarray
-        Input image.
+        Input image. The input can have any number of dimensions. The last
+        axis is treated as a channel axis only when it is omitted from
+        ``output_shape``.
     output_shape : iterable
-        Size of the generated output image `(rows, cols[, ...][, dim])`. If
-        `dim` is not provided, the number of channels is preserved. In case the
-        number of input channels does not equal the number of output channels a
-        n-dimensional interpolation is applied.
+        Size of the generated output image ``(rows, cols[, ...[, dim]])``. If
+        ``output_shape`` has one fewer entries than ``image.ndim``, the size of
+        the last input axis is preserved. To resize every axis, including the
+        last one, provide one output size for each axis.
 
     Returns
     -------


### PR DESCRIPTION
## Summary

- clarify how `resize` interprets `output_shape` for N-dimensional inputs
- explain when the last axis is preserved as channels and how to resize it explicitly

Fixes #7765