### PR TITLE
Fix Laplacian pyramid construction and reconstruction

### DIFF
--- a/src/_skimage2/transform/pyramids.py
+++ b/src/_skimage2/transform/pyramids.py
@@ -34,6 +34,18 @@ def _check_factor(factor):
         raise ValueError('scale factor must be greater than 1')
 
 
+def _pyramid_expand(image, out_shape, sigma, order, mode, cval, channel_axis):
+    resized = resize(
+        image,
+        out_shape,
+        order=order,
+        mode=mode,
+        cval=cval,
+        anti_aliasing=False,
+    )
+    return _smooth(resized, sigma, mode, cval, channel_axis)
+
+
 def pyramid_reduce(
     image,
     downscale=2,
@@ -179,12 +191,7 @@ def pyramid_expand(
         # automatically determine sigma which covers > 99% of distribution
         sigma = 2 * upscale / 6.0
 
-    resized = resize(
-        image, out_shape, order=order, mode=mode, cval=cval, anti_aliasing=False
-    )
-    out = _smooth(resized, sigma, mode, cval, channel_axis)
-
-    return out
+    return _pyramid_expand(image, out_shape, sigma, order, mode, cval, channel_axis)
 
 
 def pyramid_gaussian(
@@ -303,16 +310,17 @@ def pyramid_laplacian(
 ):
     """Yield images of the laplacian pyramid formed by the input image.
 
-    Each layer contains the difference between the downsampled and the
-    downsampled, smoothed image::
+    Each layer except the last contains the difference between a Gaussian
+    pyramid layer and the expanded subsequent Gaussian layer::
 
-        layer = resize(prev_layer) - smooth(resize(prev_layer))
+        layer = prev_layer - expand(next_layer)
 
-    Note that the first image of the pyramid will be the difference between the
-    original, unscaled image and its smoothed version. The total number of
-    images is `max_layer + 1`. In case all layers are computed, the last image
-    is either a one-pixel image or the image where the reduction does not
-    change its shape.
+    The last layer is the coarsest Gaussian pyramid layer. This residual allows
+    the original image to be reconstructed by recursively expanding each layer
+    and adding the corresponding difference image. The total number of images
+    is `max_layer + 1`. In case all layers are computed, the last image is
+    either a one-pixel image or the image where the reduction does not change
+    its shape.
 
     Parameters
     ----------
@@ -367,42 +375,30 @@ def pyramid_laplacian(
         # automatically determine sigma which covers > 99% of distribution
         sigma = 2 * downscale / 6.0
 
-    current_shape = image.shape
+    gaussian_pyramid = pyramid_gaussian(
+        image,
+        max_layer,
+        downscale,
+        sigma,
+        order,
+        mode,
+        cval,
+        preserve_range=True,
+        channel_axis=channel_axis,
+    )
+    prev_layer_image = next(gaussian_pyramid)
 
-    smoothed_image = _smooth(image, sigma, mode, cval, channel_axis)
-    yield image - smoothed_image
-
-    if channel_axis is not None:
-        channel_axis = channel_axis % image.ndim
-        shape_without_channels = list(current_shape)
-        shape_without_channels.pop(channel_axis)
-        shape_without_channels = tuple(shape_without_channels)
-    else:
-        shape_without_channels = current_shape
-
-    # build downsampled images until max_layer is reached or downscale process
-    # does not change image size
-    if max_layer == -1:
-        max_layer = math.ceil(math.log(max(shape_without_channels), downscale))
-
-    for layer in range(max_layer):
-        if channel_axis is not None:
-            out_shape = tuple(
-                math.ceil(d / float(downscale)) if ax != channel_axis else d
-                for ax, d in enumerate(current_shape)
-            )
-        else:
-            out_shape = tuple(math.ceil(d / float(downscale)) for d in current_shape)
-
-        resized_image = resize(
-            smoothed_image,
-            out_shape,
-            order=order,
-            mode=mode,
-            cval=cval,
-            anti_aliasing=False,
+    for layer_image in gaussian_pyramid:
+        expanded_image = _pyramid_expand(
+            layer_image,
+            prev_layer_image.shape,
+            sigma,
+            order,
+            mode,
+            cval,
+            channel_axis,
         )
-        smoothed_image = _smooth(resized_image, sigma, mode, cval, channel_axis)
-        current_shape = resized_image.shape
+        yield prev_layer_image - expanded_image
+        prev_layer_image = layer_image
 
-        yield resized_image - smoothed_image
+    yield prev_layer_image

--- a/tests/skimage/transform/test_pyramids.py
+++ b/tests/skimage/transform/test_pyramids.py
@@ -3,7 +3,12 @@ import warnings
 
 import pytest
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_array_equal, assert_equal
+from numpy.testing import (
+    assert_allclose,
+    assert_almost_equal,
+    assert_array_equal,
+    assert_equal,
+)
 
 from skimage import data
 from _skimage2._shared.utils import _supported_float_type
@@ -147,6 +152,52 @@ def test_build_laplacian_pyramid_nd():
         for layer, out in enumerate(pyramid):
             layer_shape = original_shape / 2**layer
             assert_array_equal(out.shape, layer_shape)
+
+
+@pytest.mark.parametrize(
+    'shape, channel_axis',
+    [((31,), None), ((31, 27), None), ((31, 27, 3), -1)],
+)
+def test_laplacian_pyramid_reconstruction(shape, channel_axis):
+    rng = np.random.RandomState(1053218495)
+    image = rng.random_sample(shape)
+    downscale = 2
+    sigma = 2 * downscale / 6.0
+    max_layer = 4
+
+    gaussian = list(
+        pyramids.pyramid_gaussian(
+            image,
+            max_layer=max_layer,
+            downscale=downscale,
+            channel_axis=channel_axis,
+        )
+    )
+    laplacian = list(
+        pyramids.pyramid_laplacian(
+            image,
+            max_layer=max_layer,
+            downscale=downscale,
+            channel_axis=channel_axis,
+        )
+    )
+
+    assert_allclose(laplacian[-1], gaussian[-1])
+
+    reconstructed = laplacian[-1]
+    for layer in reversed(laplacian[:-1]):
+        reconstructed = pyramids._pyramid_expand(
+            reconstructed,
+            layer.shape,
+            sigma,
+            order=1,
+            mode='reflect',
+            cval=0,
+            channel_axis=channel_axis,
+        )
+        reconstructed += layer
+
+    assert_allclose(reconstructed, image)
 
 
 @pytest.mark.parametrize('channel_axis', [0, 1, 2, -1, -2, -3])

--- a/tests/skimage2/transform/test_pyramids.py
+++ b/tests/skimage2/transform/test_pyramids.py
@@ -3,7 +3,12 @@ import warnings
 
 import pytest
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_array_equal, assert_equal
+from numpy.testing import (
+    assert_allclose,
+    assert_almost_equal,
+    assert_array_equal,
+    assert_equal,
+)
 
 from _skimage2 import data
 from _skimage2._shared.utils import _supported_float_type
@@ -147,6 +152,52 @@ def test_build_laplacian_pyramid_nd():
         for layer, out in enumerate(pyramid):
             layer_shape = original_shape / 2**layer
             assert_array_equal(out.shape, layer_shape)
+
+
+@pytest.mark.parametrize(
+    'shape, channel_axis',
+    [((31,), None), ((31, 27), None), ((31, 27, 3), -1)],
+)
+def test_laplacian_pyramid_reconstruction(shape, channel_axis):
+    rng = np.random.RandomState(1053218495)
+    image = rng.random_sample(shape)
+    downscale = 2
+    sigma = 2 * downscale / 6.0
+    max_layer = 4
+
+    gaussian = list(
+        pyramids.pyramid_gaussian(
+            image,
+            max_layer=max_layer,
+            downscale=downscale,
+            channel_axis=channel_axis,
+        )
+    )
+    laplacian = list(
+        pyramids.pyramid_laplacian(
+            image,
+            max_layer=max_layer,
+            downscale=downscale,
+            channel_axis=channel_axis,
+        )
+    )
+
+    assert_allclose(laplacian[-1], gaussian[-1])
+
+    reconstructed = laplacian[-1]
+    for layer in reversed(laplacian[:-1]):
+        reconstructed = pyramids._pyramid_expand(
+            reconstructed,
+            layer.shape,
+            sigma,
+            order=1,
+            mode='reflect',
+            cval=0,
+            channel_axis=channel_axis,
+        )
+        reconstructed += layer
+
+    assert_allclose(reconstructed, image)
 
 
 @pytest.mark.parametrize('channel_axis', [0, 1, 2, -1, -2, -3])


### PR DESCRIPTION
Closes #8007.

## Summary

- Construct each Laplacian difference image from adjacent Gaussian pyramid levels.
- Retain the coarsest Gaussian level as the residual needed for reconstruction.
- Expand to the preceding level's exact shape so odd-sized and multichannel inputs reconstruct correctly.
- Add mirrored regression coverage for one-dimensional, two-dimensional, and RGB inputs.

## Root cause

The previous implementation subtracted each resized image from a smoothed copy at the same resolution. It also returned a high-pass difference at the coarsest level instead of the remaining Gaussian residual. As a result, the generated pyramid discarded low-frequency information and could not reconstruct the input.

For a seeded 31-by-27 RGB input, the previous implementation produced a reconstruction RMSE of `0.5090528162921216` and a maximum error of `0.8110546865787338`. With this change, the maximum reconstruction error is approximately `1e-16`.

## Validation

- Both pyramid test modules loaded against the edited source: `102 passed`.
- Repository pre-commit hooks on all changed files: passed.
- `git diff --check`: passed.

The full editable build could not be run on the local Windows host because no C or C++ compiler is installed. The changed implementation is pure Python; targeted tests used the released scikit-image wheel for compiled dependencies while loading the edited pyramid module directly.

## AI assistance disclosure

I identified and reproduced the issue, then used OpenAI Codex to assist with the implementation and regression-test work. I personally reviewed the resulting diff and ran the validation commands listed above to verify the fix. Any full-suite or local-environment limitations are documented in the validation section.

### Release note

```release-note
`pyramid_laplacian` now produces a reconstructable Laplacian pyramid by retaining the coarsest Gaussian residual and computing difference images from adjacent Gaussian levels. Previously, the generated pyramid discarded low-frequency information and could not reconstruct the input image.
```
