### PR TITLE
Fix resize_local_mean output shape with non-last channel axis

### DIFF
--- a/src/_skimage2/transform/_warps.py
+++ b/src/_skimage2/transform/_warps.py
@@ -1325,6 +1325,10 @@ def resize_local_mean(
         image is converted according to the conventions of `img_as_float`.
         Also see
         https://scikit-image.org/docs/dev/user_guide/data_types.html
+    channel_axis : int or None, optional
+        If None, the image is assumed to be a grayscale (single channel) image.
+        Otherwise, this parameter indicates which axis of the array corresponds
+        to channels.
 
     Returns
     -------

--- a/src/_skimage2/transform/_warps.py
+++ b/src/_skimage2/transform/_warps.py
@@ -1377,7 +1377,7 @@ def resize_local_mean(
             # move channels to last position in output_shape
             channel_axis = channel_axis % image.ndim
             output_shape = (
-                output_shape[:channel_axis] + output_shape[channel_axis:] + (nc,)
+                output_shape[:channel_axis] + output_shape[channel_axis + 1 :] + (nc,)
             )
         else:
             raise ValueError(

--- a/tests/skimage/transform/test_warps.py
+++ b/tests/skimage/transform/test_warps.py
@@ -939,22 +939,22 @@ def test_resize_local_mean2d():
 def test_resize_local_mean3d_keep(channel_axis):
     # keep 3rd dimension
     nch = 3
-    x = np.zeros((5, 5, nch), dtype=np.float64)
+    x = np.zeros((4, 5, nch), dtype=np.float64)
     x[1, 1, :] = 1
     # move channels to expected dimension
     x = np.moveaxis(x, -1, channel_axis)
-    resized = resize_local_mean(x, (10, 10), channel_axis=channel_axis)
+    resized = resize_local_mean(x, (8, 10), channel_axis=channel_axis)
     # move channels back to last axis to match the reference image
     resized = np.moveaxis(resized, channel_axis, -1)
     with pytest.raises(ValueError):
         # output_shape too short
         resize_local_mean(x, (10,))
-    ref = np.zeros((10, 10, nch))
+    ref = np.zeros((8, 10, nch))
     ref[2:4, 2:4, :] = 1
     assert_array_almost_equal(resized, ref)
 
     channel_axis = channel_axis % x.ndim
-    spatial_shape = (10, 10)
+    spatial_shape = (8, 10)
     out_shape = spatial_shape[:channel_axis] + (nch,) + spatial_shape[channel_axis:]
     resized = resize_local_mean(x, out_shape, channel_axis=channel_axis)
     # move channels back to last axis to match the reference image

--- a/tests/skimage/transform/test_warps.py
+++ b/tests/skimage/transform/test_warps.py
@@ -956,7 +956,7 @@ def test_resize_local_mean3d_keep(channel_axis):
     channel_axis = channel_axis % x.ndim
     spatial_shape = (10, 10)
     out_shape = spatial_shape[:channel_axis] + (nch,) + spatial_shape[channel_axis:]
-    resized = resize_local_mean(x, out_shape)
+    resized = resize_local_mean(x, out_shape, channel_axis=channel_axis)
     # move channels back to last axis to match the reference image
     resized = np.moveaxis(resized, channel_axis, -1)
     assert_array_almost_equal(resized, ref)

--- a/tests/skimage2/transform/test_warps.py
+++ b/tests/skimage2/transform/test_warps.py
@@ -939,22 +939,22 @@ def test_resize_local_mean2d():
 def test_resize_local_mean3d_keep(channel_axis):
     # keep 3rd dimension
     nch = 3
-    x = np.zeros((5, 5, nch), dtype=np.float64)
+    x = np.zeros((4, 5, nch), dtype=np.float64)
     x[1, 1, :] = 1
     # move channels to expected dimension
     x = np.moveaxis(x, -1, channel_axis)
-    resized = resize_local_mean(x, (10, 10), channel_axis=channel_axis)
+    resized = resize_local_mean(x, (8, 10), channel_axis=channel_axis)
     # move channels back to last axis to match the reference image
     resized = np.moveaxis(resized, channel_axis, -1)
     with pytest.raises(ValueError):
         # output_shape too short
         resize_local_mean(x, (10,))
-    ref = np.zeros((10, 10, nch))
+    ref = np.zeros((8, 10, nch))
     ref[2:4, 2:4, :] = 1
     assert_array_almost_equal(resized, ref)
 
     channel_axis = channel_axis % x.ndim
-    spatial_shape = (10, 10)
+    spatial_shape = (8, 10)
     out_shape = spatial_shape[:channel_axis] + (nch,) + spatial_shape[channel_axis:]
     resized = resize_local_mean(x, out_shape, channel_axis=channel_axis)
     # move channels back to last axis to match the reference image

--- a/tests/skimage2/transform/test_warps.py
+++ b/tests/skimage2/transform/test_warps.py
@@ -956,7 +956,7 @@ def test_resize_local_mean3d_keep(channel_axis):
     channel_axis = channel_axis % x.ndim
     spatial_shape = (10, 10)
     out_shape = spatial_shape[:channel_axis] + (nch,) + spatial_shape[channel_axis:]
-    resized = resize_local_mean(x, out_shape)
+    resized = resize_local_mean(x, out_shape, channel_axis=channel_axis)
     # move channels back to last axis to match the reference image
     resized = np.moveaxis(resized, channel_axis, -1)
     assert_array_almost_equal(resized, ref)


### PR DESCRIPTION
Fixes #8276.
Fixes #8280.

### Summary

`resize_local_mean` accepts an `output_shape` that either omits the channel dimension or includes the unchanged channel dimension when `channel_axis` is set. For non-last channel axes, the explicit form retained the original channel entry while also appending it, producing an extra dimension that was later silently truncated.

This change:

- excludes the original channel entry when moving the channel dimension to the internal last position;
- updates both mirrored parameterized tests so the full output-shape form is actually exercised with `channel_axis`;
- verifies that channels-first, channels-middle, and channels-last inputs preserve the documented output layout.

Before the fix, a channels-first `(3, 4, 5)` image resized with explicit output shape `(3, 2, 10)` produced `(10, 3, 2)`. It now produces `(3, 2, 10)` and is equivalent to the omitted-channel form.

### Validation

- `python -m pytest tests/skimage/transform/test_warps.py -q` - 149 passed
- `python -m pytest tests/skimage2/transform/test_warps.py -q` - 149 passed
- `python -m ruff check src/_skimage2/transform/_warps.py tests/skimage/transform/test_warps.py tests/skimage2/transform/test_warps.py` - passed
- `python -m ruff format --check src/_skimage2/transform/_warps.py tests/skimage/transform/test_warps.py tests/skimage2/transform/test_warps.py` - passed
- `git diff --check` - passed

### Generative-tool disclosure

I used OpenAI Codex to assist with repository auditing, reproduction, implementation, and test execution. I reviewed the complete three-line diff and the affected code path. The commit includes the required `Assisted-by:` trailer.


