### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.github/workflows/wheels-recipe.yaml
+++ b/.github/workflows/wheels-recipe.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: pypa/cibuildwheel@v3.2.1
+      - uses: pypa/cibuildwheel@9c00cb4f6b517705a3794b22395aedc36257242c # v3.2.1
         env:
           CIBW_BUILD: ${{ matrix.build }}
       - uses: actions/upload-artifact@v4
@@ -55,7 +55,7 @@ jobs:
       - name: Set up LLVM toolchain for Windows ARM64
         if: matrix.os == 'windows-11-arm'
         uses: ./.github/windows_arm64_steps
-      - uses: pypa/cibuildwheel@v3.2.1
+      - uses: pypa/cibuildwheel@9c00cb4f6b517705a3794b22395aedc36257242c # v3.2.1
         env:
           CIBW_BUILD: ${{ matrix.build }}
           CC: clang-cl
@@ -90,7 +90,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: pypa/cibuildwheel@v3.2.1
+      - uses: pypa/cibuildwheel@9c00cb4f6b517705a3794b22395aedc36257242c # v3.2.1
         env:
           CIBW_BUILD: ${{ matrix.build }}
       - uses: actions/upload-artifact@v4
@@ -108,7 +108,7 @@ jobs:
           persist-credentials: false
 
       - name: Build and test scikit-image for Pyodide
-        uses: pypa/cibuildwheel@v3.2.1
+        uses: pypa/cibuildwheel@9c00cb4f6b517705a3794b22395aedc36257242c # v3.2.1
         env:
           CIBW_PLATFORM: pyodide
           # only build for newer pyodide_2025_0 ABI and not cp312-pyodide_wasm32 (pyodide_2024_0)

--- a/.github/workflows/wheels-test-and-release.yaml
+++ b/.github/workflows/wheels-test-and-release.yaml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - uses: hynek/build-and-inspect-python-package@v2
+      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
         with:
           attest-build-provenance-github: ${{ github.event_name == 'push' && 'true' || 'false' }}
           skip-wheel: "true"
@@ -74,7 +74,8 @@ jobs:
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
 
       - name: Github release
-        uses: softprops/action-gh-release@v2
+        # zizmor: ignore[superfluous-actions]
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,11 @@
+# https://docs.zizmor.sh/configuration/
+
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # Actions published by GitHub itself are updated by Dependabot and are
+        # trusted to the same degree as the runner, so a version tag suffices.
+        "actions/*": ref-pin
+        # Everything else must be pinned to a full commit hash.
+        "*": hash-pin

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # frozen: v5.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -16,21 +16,21 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: bc7af46104f0f5368b95878decf720f9f00c2559 # frozen: v3.4.2
+    rev: 0ee178619d696787ca73d210cc191d720868c631 # frozen: v3.9.6
     hooks:
       - id: prettier
         files: \.(md|rst|yml|yaml)
         args: [--prose-wrap=preserve]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 89c421dff2e1026ba12cdb9ebd731f4a83aa8021 # frozen: v0.8.6
+    rev: 65dbdb59d2f2d9c3bdc343c566821ad3319ddaa3 # frozen: v0.16.3
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --show-fixes, --exit-non-zero-on-fix]
       - id: ruff-format
 
   - repo: https://github.com/MarcoGorelli/cython-lint
-    rev: 1ac5158c1b0f405350517c218f03d3a21bbb381c # frozen: v0.16.6
+    rev: 399947374c9564f1d3bf9921c94ff8b71fc15f4e # frozen: v0.21.0
     hooks:
       - id: cython-lint
         args: [--no-pycodestyle, --max-line-length=88]
@@ -44,7 +44,7 @@ repos:
         files: "pyproject.toml|requirements/.*\\.txt|tools/generate_requirements.py"
 
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: a0912e39df36b50365d8cdfb123c0e013dc6e50d # v1.3.0
+    rev: 451b56af716f9f0d0c2b816503a3fd0cf8b036fa # frozen: v1.29.0
     hooks:
       - id: zizmor
 

--- a/doc/examples/edges/plot_random_shapes.py
+++ b/doc/examples/edges/plot_random_shapes.py
@@ -40,7 +40,7 @@ image4, _ = random_shapes((128, 128), max_shapes=10, intensity_range=((0, 255),)
 
 for i, image in enumerate([image1, image2, image3, image4], 1):
     ax[i].imshow(image)
-    ax[i].set_title(f'Colored shapes, #{i-1}')
+    ax[i].set_title(f'Colored shapes, #{i - 1}')
 
 # These shapes are well suited to test segmentation algorithms. Often, we
 # want shapes to overlap to test the algorithm. This is also possible:

--- a/doc/examples/features_detection/plot_sift.py
+++ b/doc/examples/features_detection/plot_sift.py
@@ -73,7 +73,7 @@ plot_matched_features(
     ax=ax[0, 0],
 )
 ax[0, 0].axis('off')
-ax[0, 0].set_title("Original Image vs. Flipped Image\n" "(all keypoints and matches)")
+ax[0, 0].set_title("Original Image vs. Flipped Image\n(all keypoints and matches)")
 
 plot_matched_features(
     img1,
@@ -84,9 +84,7 @@ plot_matched_features(
     ax=ax[1, 0],
 )
 ax[1, 0].axis('off')
-ax[1, 0].set_title(
-    "Original Image vs. Transformed Image\n" "(all keypoints and matches)"
-)
+ax[1, 0].set_title("Original Image vs. Transformed Image\n(all keypoints and matches)")
 
 plot_matched_features(
     img1,
@@ -99,7 +97,7 @@ plot_matched_features(
 )
 ax[0, 1].axis('off')
 ax[0, 1].set_title(
-    "Original Image vs. Flipped Image\n" "(subset of matches for visibility)"
+    "Original Image vs. Flipped Image\n(subset of matches for visibility)"
 )
 
 plot_matched_features(
@@ -113,7 +111,7 @@ plot_matched_features(
 )
 ax[1, 1].axis('off')
 ax[1, 1].set_title(
-    "Original Image vs. Transformed Image\n" "(subset of matches for visibility)"
+    "Original Image vs. Transformed Image\n(subset of matches for visibility)"
 )
 
 plt.tight_layout()

--- a/doc/examples/filters/plot_cycle_spinning.py
+++ b/doc/examples/filters/plot_cycle_spinning.py
@@ -71,7 +71,7 @@ for n, s in enumerate(max_shifts):
     if s == 0:
         ax[n + 1].set_title(f'Denoised: no cycle shifts\nPSNR={psnr:0.4g}')
     else:
-        ax[n + 1].set_title(f'Denoised: {s+1}x{s+1} shifts\nPSNR={psnr:0.4g}')
+        ax[n + 1].set_title(f'Denoised: {s + 1}x{s + 1} shifts\nPSNR={psnr:0.4g}')
     all_psnr.append(psnr)
 
 # plot PSNR as a function of the degree of cycle shifting

--- a/doc/examples/filters/plot_j_invariant_tutorial.py
+++ b/doc/examples/filters/plot_j_invariant_tutorial.py
@@ -224,7 +224,7 @@ ax.scatter(
 )
 ax.legend()
 ax.set_title(
-    'J-Invariant Denoiser Has Comparable Or ' 'Better Performance At Same Parameters'
+    'J-Invariant Denoiser Has Comparable Or Better Performance At Same Parameters'
 )
 ax.set_ylabel('MSE')
 ax.set_xlabel('sigma')

--- a/doc/examples/registration/plot_register_rotation.py
+++ b/doc/examples/registration/plot_register_rotation.py
@@ -63,8 +63,8 @@ plt.show()
 shifts, error, phasediff = phase_cross_correlation(
     image_polar, rotated_polar, normalization=None
 )
-print(f'Expected value for counterclockwise rotation in degrees: ' f'{angle}')
-print(f'Recovered value for counterclockwise rotation: ' f'{shifts[0]}')
+print(f'Expected value for counterclockwise rotation in degrees: {angle}')
+print(f'Recovered value for counterclockwise rotation: {shifts[0]}')
 
 ######################################################################
 # Recover rotation and scaling differences with log-polar transform

--- a/doc/examples/transform/plot_radon_transform.py
+++ b/doc/examples/transform/plot_radon_transform.py
@@ -172,9 +172,7 @@ from skimage.transform import iradon_sart
 
 reconstruction_sart = iradon_sart(sinogram, theta=theta)
 error = reconstruction_sart - image
-print(
-    f'SART (1 iteration) rms reconstruction error: ' f'{np.sqrt(np.mean(error**2)):.3g}'
-)
+print(f'SART (1 iteration) rms reconstruction error: {np.sqrt(np.mean(error**2)):.3g}')
 
 fig, axes = plt.subplots(2, 2, figsize=(8, 8.5), sharex=True, sharey=True)
 ax = axes.ravel()
@@ -189,10 +187,7 @@ ax[1].imshow(reconstruction_sart - image, cmap=plt.cm.Greys_r, **imkwargs)
 # from the first iteration as an initial estimate
 reconstruction_sart2 = iradon_sart(sinogram, theta=theta, image=reconstruction_sart)
 error = reconstruction_sart2 - image
-print(
-    f'SART (2 iterations) rms reconstruction error: '
-    f'{np.sqrt(np.mean(error**2)):.3g}'
-)
+print(f'SART (2 iterations) rms reconstruction error: {np.sqrt(np.mean(error**2)):.3g}')
 
 ax[2].set_title("Reconstruction\nSART, 2 iterations")
 ax[2].imshow(reconstruction_sart2, cmap=plt.cm.Greys_r)

--- a/src/_skimage2/color/colorconv.py
+++ b/src/_skimage2/color/colorconv.py
@@ -164,10 +164,7 @@ def _prepare_colorarray(arr, force_copy=False, *, channel_axis=-1):
     arr = np.asanyarray(arr)
 
     if arr.shape[channel_axis] != 3:
-        msg = (
-            f'the input array must have size 3 along `channel_axis`, '
-            f'got {arr.shape}'
-        )
+        msg = f'the input array must have size 3 along `channel_axis`, got {arr.shape}'
         raise ValueError(msg)
 
     float_dtype = _supported_float_type(arr.dtype)
@@ -229,10 +226,7 @@ def rgba2rgb(rgba, background=(1, 1, 1), *, channel_axis=-1):
     channel_axis = channel_axis % arr.ndim
 
     if arr.shape[channel_axis] != 4:
-        msg = (
-            f'the input array must have size 4 along `channel_axis`, '
-            f'got {arr.shape}'
-        )
+        msg = f'the input array must have size 4 along `channel_axis`, got {arr.shape}'
         raise ValueError(msg)
 
     float_dtype = _supported_float_type(arr.dtype)
@@ -248,7 +242,7 @@ def rgba2rgb(rgba, background=(1, 1, 1), *, channel_axis=-1):
             f'values. Got {len(background)} items'
         )
     if np.any(background < 0) or np.any(background > 1):
-        raise ValueError('background RGB values must be floats between ' '0 and 1.')
+        raise ValueError('background RGB values must be floats between 0 and 1.')
     # reshape background for broadcasting along non-channel axes
     background = reshape_nd(background, arr.ndim, channel_axis)
 
@@ -626,8 +620,7 @@ def xyz_tristimulus_values(*, illuminant, observer, dtype=float):
         return np.asarray(_illuminants[illuminant][observer], dtype=dtype)
     except KeyError:
         raise ValueError(
-            f'Unknown illuminant/observer combination '
-            f'(`{illuminant}`, `{observer}`)'
+            f'Unknown illuminant/observer combination (`{illuminant}`, `{observer}`)'
         )
 
 

--- a/src/_skimage2/exposure/exposure.py
+++ b/src/_skimage2/exposure/exposure.py
@@ -119,7 +119,7 @@ def _get_outer_edges(image, hist_range):
             raise ValueError("max must be larger than min in hist_range parameter.")
         if not (np.isfinite(first_edge) and np.isfinite(last_edge)):
             raise ValueError(
-                f'supplied hist_range of [{first_edge}, {last_edge}] is ' f'not finite'
+                f'supplied hist_range of [{first_edge}, {last_edge}] is not finite'
             )
     elif image.size == 0:
         # handle empty arrays. Can't determine hist_range, so use 0-1.
@@ -128,8 +128,7 @@ def _get_outer_edges(image, hist_range):
         first_edge, last_edge = image.min(), image.max()
         if not (np.isfinite(first_edge) and np.isfinite(last_edge)):
             raise ValueError(
-                f'autodetected hist_range of [{first_edge}, {last_edge}] is '
-                f'not finite'
+                f'autodetected hist_range of [{first_edge}, {last_edge}] is not finite'
             )
 
     # expand empty hist_range to avoid divide by zero

--- a/src/_skimage2/exposure/histogram_matching.py
+++ b/src/_skimage2/exposure/histogram_matching.py
@@ -65,15 +65,12 @@ def match_histograms(image, reference, *, channel_axis=None):
 
     """
     if image.ndim != reference.ndim:
-        raise ValueError(
-            'Image and reference must have the same number ' 'of channels.'
-        )
+        raise ValueError('Image and reference must have the same number of channels.')
 
     if channel_axis is not None:
         if image.shape[-1] != reference.shape[-1]:
             raise ValueError(
-                'Number of channels in the input image and '
-                'reference image must match!'
+                'Number of channels in the input image and reference image must match!'
             )
 
         matched = np.empty(image.shape, dtype=image.dtype)

--- a/src/_skimage2/feature/_fisher_vector.py
+++ b/src/_skimage2/feature/_fisher_vector.py
@@ -109,7 +109,7 @@ def learn_gmm(descriptors, *, n_modes=32, gm_args=None):
         ranks = [len(e.shape) == len(expected_shape) for e in descriptors]
         if not all(ranks):
             raise DescriptorException(
-                'Please ensure all elements of your descriptor list ' 'are of rank 2.'
+                'Please ensure all elements of your descriptor list are of rank 2.'
             )
         dims = [e.shape[1] == descriptors[0].shape[1] for e in descriptors]
         if not all(dims):

--- a/src/_skimage2/feature/_sift.pyx
+++ b/src/_skimage2/feature/_sift.pyx
@@ -152,8 +152,8 @@ cpdef _local_max(np_floats[:, :, ::1] octave, cnp.float64_t thresh):
                     if val <= center_val:
                         is_local_max = True
                         is_local_min = False
-                        for offset in neighbor_offsets:
-                            val = center_ptr[offset]
+                        for offset2 in neighbor_offsets:
+                            val = center_ptr[offset2]
                             if val >= center_val:
                                 is_local_max = False
                                 break

--- a/src/_skimage2/feature/censure.py
+++ b/src/_skimage2/feature/censure.py
@@ -246,7 +246,7 @@ class CENSURE(FeatureDetector):
 
         if min_scale < 1 or max_scale < 1 or max_scale - min_scale < 2:
             raise ValueError(
-                'The scales must be >= 1 and the number of ' 'scales should be >= 3.'
+                'The scales must be >= 1 and the number of scales should be >= 3.'
             )
 
         self.min_scale = min_scale

--- a/src/_skimage2/feature/corner.py
+++ b/src/_skimage2/feature/corner.py
@@ -112,7 +112,7 @@ def structure_tensor(image, sigma=1, mode='constant', cval=0, order='rc'):
     if not np.isscalar(sigma):
         sigma = tuple(sigma)
         if len(sigma) != image.ndim:
-            raise ValueError('sigma must have as many elements as image ' 'has axes')
+            raise ValueError('sigma must have as many elements as image has axes')
 
     image = _prepare_grayscale_input_nD(image)
 

--- a/src/_skimage2/feature/haar.py
+++ b/src/_skimage2/feature/haar.py
@@ -208,7 +208,7 @@ def haar_like_feature(
     else:
         if feature_coord.shape[0] != feature_type.shape[0]:
             raise ValueError(
-                "Inconsistent size between feature coordinatesand feature types."
+                "Inconsistent size between feature coordinates and feature types."
             )
 
         mask_feature = [feature_type == feat_t for feat_t in FEATURE_TYPE]

--- a/src/_skimage2/feature/haar.py
+++ b/src/_skimage2/feature/haar.py
@@ -208,7 +208,7 @@ def haar_like_feature(
     else:
         if feature_coord.shape[0] != feature_type.shape[0]:
             raise ValueError(
-                "Inconsistent size between feature coordinates" "and feature types."
+                "Inconsistent size between feature coordinatesand feature types."
             )
 
         mask_feature = [feature_type == feat_t for feat_t in FEATURE_TYPE]

--- a/src/_skimage2/filters/rank/core_cy.pyx
+++ b/src/_skimage2/filters/rank/core_cy.pyx
@@ -82,7 +82,7 @@ cdef void _core(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t[::1], cnp.float
         mask_data = &mask[0, 0]
 
     # define local variable types
-    cdef Py_ssize_t r, c, rr, cc, s, even_row
+    cdef Py_ssize_t r, c, rr, cc, s, _even_row
 
     # number of pixels actually inside the neighborhood (cnp.float64_t)
     cdef cnp.float64_t pop = 0
@@ -163,7 +163,7 @@ cdef void _core(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t[::1], cnp.float
 
         # main loop
         r = 0
-        for even_row in range(0, rows, 2):
+        for _even_row in range(0, rows, 2):
 
             # ---> west to east
             for c in range(1, cols):

--- a/src/_skimage2/filters/rank/core_cy_3d.pyx
+++ b/src/_skimage2/filters/rank/core_cy_3d.pyx
@@ -205,7 +205,7 @@ cdef void _core_3D(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t[::1], cnp.fl
     cdef char* mask_data = &mask[0, 0, 0]
 
     # define local variable types
-    cdef Py_ssize_t p, r, c, even_row
+    cdef Py_ssize_t p, r, c, _even_row
 
     # number of pixels actually inside the neighborhood (cnp.float64_t)
     cdef cnp.float64_t pop = 0
@@ -242,7 +242,7 @@ cdef void _core_3D(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t[::1], cnp.fl
         with nogil:
             # main loop
 
-            for even_row in range(0, rows, 2):
+            for _even_row in range(0, rows, 2):
 
                 # ---> west to east
                 for c in range(1, cols):

--- a/src/_skimage2/filters/rank/generic.py
+++ b/src/_skimage2/filters/rank/generic.py
@@ -146,7 +146,7 @@ def _preprocess_input(
 
     footprint = np.ascontiguousarray(img_as_ubyte(footprint > 0))
     if footprint.ndim != image.ndim:
-        raise ValueError('Image dimensions and neighborhood dimensionsdo not match')
+        raise ValueError('Image dimensions and neighborhood dimensions do not match')
 
     image = np.ascontiguousarray(image)
 
@@ -253,7 +253,7 @@ def _handle_input_3D(
 
     footprint = np.ascontiguousarray(img_as_ubyte(footprint > 0))
     if footprint.ndim != image.ndim:
-        raise ValueError('Image dimensions and neighborhood dimensionsdo not match')
+        raise ValueError('Image dimensions and neighborhood dimensions do not match')
     image = np.ascontiguousarray(image)
 
     if mask is None:

--- a/src/_skimage2/filters/rank/generic.py
+++ b/src/_skimage2/filters/rank/generic.py
@@ -146,7 +146,7 @@ def _preprocess_input(
 
     footprint = np.ascontiguousarray(img_as_ubyte(footprint > 0))
     if footprint.ndim != image.ndim:
-        raise ValueError('Image dimensions and neighborhood dimensions' 'do not match')
+        raise ValueError('Image dimensions and neighborhood dimensionsdo not match')
 
     image = np.ascontiguousarray(image)
 
@@ -253,7 +253,7 @@ def _handle_input_3D(
 
     footprint = np.ascontiguousarray(img_as_ubyte(footprint > 0))
     if footprint.ndim != image.ndim:
-        raise ValueError('Image dimensions and neighborhood dimensions' 'do not match')
+        raise ValueError('Image dimensions and neighborhood dimensionsdo not match')
     image = np.ascontiguousarray(image)
 
     if mask is None:

--- a/src/_skimage2/filters/thresholding.py
+++ b/src/_skimage2/filters/thresholding.py
@@ -872,7 +872,7 @@ def threshold_minimum(image=None, nbins=256, max_num_iter=10000, *, hist=None):
     if len(maximum_idxs) != 2:
         raise RuntimeError('Unable to find two maxima in histogram')
     elif counter == max_num_iter - 1:
-        raise RuntimeError('Maximum iteration reached for histogram' 'smoothing')
+        raise RuntimeError('Maximum iteration reached for histogramsmoothing')
 
     # Find the lowest point between the maxima
     threshold_idx = np.argmin(smooth_hist[maximum_idxs[0] : maximum_idxs[1] + 1])

--- a/src/_skimage2/filters/thresholding.py
+++ b/src/_skimage2/filters/thresholding.py
@@ -872,7 +872,7 @@ def threshold_minimum(image=None, nbins=256, max_num_iter=10000, *, hist=None):
     if len(maximum_idxs) != 2:
         raise RuntimeError('Unable to find two maxima in histogram')
     elif counter == max_num_iter - 1:
-        raise RuntimeError('Maximum iteration reached for histogramsmoothing')
+        raise RuntimeError('Maximum iteration reached for histogram smoothing')
 
     # Find the lowest point between the maxima
     threshold_idx = np.argmin(smooth_hist[maximum_idxs[0] : maximum_idxs[1] + 1])

--- a/src/_skimage2/graph/_mcp.pyx
+++ b/src/_skimage2/graph/_mcp.pyx
@@ -261,7 +261,7 @@ cdef class MCP:
 
         # Check sampling
         if sampling is None:
-            sampling = np.array([1.0 for s in costs.shape], FLOAT_D)
+            sampling = np.array([1.0 for _s in costs.shape], FLOAT_D)
         elif isinstance(sampling, (list, tuple)):
             sampling = np.array(sampling, FLOAT_D)
             if sampling.ndim != 1 or len(sampling) != costs.ndim:
@@ -498,7 +498,7 @@ cdef class MCP:
         cdef FLOAT_T cost, new_cost, cumcost, new_cumcost, offset_length
         cdef INDEX_T index, new_index
         cdef BOOL_T is_at_edge, use_offset
-        cdef INDEX_T d, i, iter
+        cdef INDEX_T d, i, _iter
         cdef OFFSET_T offset
         cdef EDGE_T pos_edge_val, neg_edge_val
         cdef int num_ends_found = 0
@@ -507,7 +507,7 @@ cdef class MCP:
 
         cdef INDEX_T maxiter = int(max_coverage * flat_costs.size)
 
-        for iter in range(maxiter):
+        for _iter in range(maxiter):
 
             # This is rather like a while loop, except we are guaranteed to
             # exit, which is nice during developing to prevent eternal loops.

--- a/src/_skimage2/graph/heap.pyx
+++ b/src/_skimage2/graph/heap.pyx
@@ -238,8 +238,8 @@ cdef class BinaryHeap:
 
         # track tree
         cdef INDEX_T ii
-        cdef LEVELS_T level
-        for level in range(self.levels, 1, -1):
+        cdef LEVELS_T _level
+        for _level in range(self.levels, 1, -1):
             ii = (i-1) // 2  # CalcPrevAbs
 
             # test
@@ -321,11 +321,11 @@ cdef class BinaryHeap:
         cdef VALUE_T *values = self._values
 
         # init index. start at 1 because we start in level 1
-        cdef LEVELS_T level
+        cdef LEVELS_T _level
         cdef INDEX_T i = 1
         cdef LEVELS_T levels = self.levels
         # search tree (using absolute indices)
-        for level in range(1, levels):
+        for _level in range(1, levels):
             if values[i] <= values[i+1]:
                 i = i * 2 + 1  # CalcNextAbs
             else:

--- a/src/_skimage2/io/_plugins/imread_plugin.py
+++ b/src/_skimage2/io/_plugins/imread_plugin.py
@@ -6,7 +6,7 @@ try:
     import imread as _imread
 except ImportError:
     raise ImportError(
-        "Imread could not be found"
+        "Imread could not be found. "
         "Please refer to http://pypi.python.org/pypi/imread/ "
         "for further instructions."
     )

--- a/src/_skimage2/io/_plugins/matplotlib_plugin.py
+++ b/src/_skimage2/io/_plugins/matplotlib_plugin.py
@@ -70,12 +70,12 @@ def _raise_warnings(image_properties):
     ip = image_properties
     if ip.unsupported_dtype:
         warn(
-            "Non-standard image type; displaying image with " "stretched contrast.",
+            "Non-standard image type; displaying image with stretched contrast.",
             stacklevel=3,
         )
     if ip.low_data_range:
         warn(
-            "Low image data range; displaying image with " "stretched contrast.",
+            "Low image data range; displaying image with stretched contrast.",
             stacklevel=3,
         )
     if ip.out_of_range_float:

--- a/src/_skimage2/measure/_ccomp.pyx
+++ b/src/_skimage2/measure/_ccomp.pyx
@@ -485,11 +485,11 @@ cdef void scan1D(DTYPE_t *data_p, DTYPE_t *forest_p, shape_info *shapeinfo,
     if shapeinfo.numels == 0:
         return
     # Initialize the first row
-    cdef DTYPE_t x, rindex, bgval = bg.background_val
+    cdef DTYPE_t _x, rindex, bgval = bg.background_val
     cdef DTYPE_t *DEX = shapeinfo.DEX
     rindex = shapeinfo.ravel_index(0, y, z, shapeinfo)
 
-    for x in range(1, shapeinfo.x):
+    for _x in range(1, shapeinfo.x):
         rindex += 1
         # Handle the first row
         if data_p[rindex] == bgval:
@@ -506,7 +506,7 @@ cdef void scan2D(DTYPE_t *data_p, DTYPE_t *forest_p, shape_info *shapeinfo,
     """
     if shapeinfo.numels == 0:
         return
-    cdef DTYPE_t x, y, rindex, bgval = bg.background_val
+    cdef DTYPE_t _x, y, rindex, bgval = bg.background_val
     cdef DTYPE_t *DEX = shapeinfo.DEX
     scan1D(data_p, forest_p, shapeinfo, bg, connectivity, 0, z)
     for y in range(1, shapeinfo.y):
@@ -522,7 +522,7 @@ cdef void scan2D(DTYPE_t *data_p, DTYPE_t *forest_p, shape_info *shapeinfo,
                 join_trees_wrapper(data_p, forest_p, rindex, DEX[D_ec])
         # END of x = 0
 
-        for x in range(1, shapeinfo.x - 1):
+        for _x in range(1, shapeinfo.x - 1):
             # We have just moved to another column (of the same row)
             # so we increment the raveled index. It will be reset when we get
             # to another row, so we don't have to worry about altering it here.
@@ -560,7 +560,7 @@ cdef void scan3D(DTYPE_t *data_p, DTYPE_t *forest_p, shape_info *shapeinfo,
     """
     if shapeinfo.numels == 0:
         return
-    cdef DTYPE_t x, y, z, rindex, bgval = bg.background_val
+    cdef DTYPE_t _x, y, z, rindex, bgval = bg.background_val
     cdef DTYPE_t *DEX = shapeinfo.DEX
     # Handle first plane
     scan2D(data_p, forest_p, shapeinfo, bg, connectivity, 0)
@@ -582,7 +582,7 @@ cdef void scan3D(DTYPE_t *data_p, DTYPE_t *forest_p, shape_info *shapeinfo,
                     join_trees_wrapper(data_p, forest_p, rindex, DEX[D_en])
         # END of x = 0
 
-        for x in range(1, shapeinfo.x - 1):
+        for _x in range(1, shapeinfo.x - 1):
             rindex += 1
             # Handle the first row
             if data_p[rindex] == bgval:
@@ -639,7 +639,7 @@ cdef void scan3D(DTYPE_t *data_p, DTYPE_t *forest_p, shape_info *shapeinfo,
             # END of x = 0
 
             # Handle the rest of columns
-            for x in range(1, shapeinfo.x - 1):
+            for _x in range(1, shapeinfo.x - 1):
                 rindex += 1
                 if data_p[rindex] == bgval:
                     # Nothing to do if we are background
@@ -701,7 +701,7 @@ cdef void scan3D(DTYPE_t *data_p, DTYPE_t *forest_p, shape_info *shapeinfo,
         # END of x = 0
 
         # Handle the rest of columns
-        for x in range(1, shapeinfo.x - 1):
+        for _x in range(1, shapeinfo.x - 1):
             rindex += 1
             if data_p[rindex] == bgval:
                 # Nothing to do if we are background

--- a/src/_skimage2/measure/_find_contours.py
+++ b/src/_skimage2/measure/_find_contours.py
@@ -123,12 +123,10 @@ def find_contours(
            [0.5, 0. ]])]
     """
     if fully_connected not in _param_options:
-        raise ValueError(
-            'Parameters "fully_connected" must be either ' '"high" or "low".'
-        )
+        raise ValueError('Parameters "fully_connected" must be either "high" or "low".')
     if positive_orientation not in _param_options:
         raise ValueError(
-            'Parameters "positive_orientation" must be either ' '"high" or "low".'
+            'Parameters "positive_orientation" must be either "high" or "low".'
         )
     if image.shape[0] < 2 or image.shape[1] < 2:
         raise ValueError("Input array must be at least 2x2.")
@@ -136,7 +134,7 @@ def find_contours(
         raise ValueError('Only 2D arrays are supported.')
     if mask is not None:
         if mask.shape != image.shape:
-            raise ValueError('Parameters "array" and "mask"' ' must have same shape.')
+            raise ValueError('Parameters "array" and "mask" must have same shape.')
         if not np.can_cast(mask.dtype, bool, casting='safe'):
             raise TypeError('Parameter "mask" must be a binary array.')
         mask = mask.astype(np.uint8, copy=False)

--- a/src/_skimage2/measure/_polygon.py
+++ b/src/_skimage2/measure/_polygon.py
@@ -131,7 +131,7 @@ def subdivide_polygon(coords, degree=2, preserve_ends=False):
     .. [1] http://mrl.nyu.edu/publications/subdiv-course2000/coursenotes00.pdf
     """
     if degree not in _SUBDIVISION_MASKS:
-        raise ValueError("Invalid B-Spline degree. Only degree 1 - 7 is " "supported.")
+        raise ValueError("Invalid B-Spline degree. Only degree 1 - 7 is supported.")
 
     circular = np.all(coords[0, :] == coords[-1, :])
 

--- a/src/_skimage2/measure/block.py
+++ b/src/_skimage2/measure/block.py
@@ -64,7 +64,7 @@ def block_reduce(image, block_size=2, func=np.sum, cval=0, func_kwargs=None):
         block_size = (block_size,) * image.ndim
     elif len(block_size) != image.ndim:
         raise ValueError(
-            "`block_size` must be a scalar or have " "the same length as `image.shape`"
+            "`block_size` must be a scalar or have the same length as `image.shape`"
         )
 
     if func_kwargs is None:

--- a/src/_skimage2/measure/fit.py
+++ b/src/_skimage2/measure/fit.py
@@ -1147,13 +1147,12 @@ def add_from_estimate(cls):
 
     if hasattr(cls, 'from_estimate'):
         if not inspect.ismethod(cls.from_estimate):
-            raise TypeError(f'Class {cls} `from_estimate` must be a ' 'class method.')
+            raise TypeError(f'Class {cls} `from_estimate` must be a class method.')
         return cls
 
     if not hasattr(cls, 'estimate'):
         raise TypeError(
-            f'Class {cls} must have `from_estimate` class method '
-            'or `estimate` method.'
+            f'Class {cls} must have `from_estimate` class method or `estimate` method.'
         )
 
     warn(

--- a/src/_skimage2/metrics/simple_metrics.py
+++ b/src/_skimage2/metrics/simple_metrics.py
@@ -145,8 +145,7 @@ def peak_signal_noise_ratio(image_true, image_test, *, data_range=None):
     if data_range is None:
         if image_true.dtype != image_test.dtype:
             warn(
-                "Inputs have mismatched dtype.  Setting data_range based on "
-                "image_true."
+                "Inputs have mismatched dtype.  Setting data_range based on image_true."
             )
         dmin, dmax = dtype_range[image_true.dtype.type]
         true_min, true_max = np.min(image_true), np.max(image_true)

--- a/src/_skimage2/morphology/_skeletonize.py
+++ b/src/_skimage2/morphology/_skeletonize.py
@@ -81,17 +81,17 @@ def skeletonize(image, *, method=None):
 
     if method not in {'zhang', 'lee', None}:
         raise ValueError(
-            f'skeletonize method should be either "lee" or "zhang", ' f'got {method}.'
+            f'skeletonize method should be either "lee" or "zhang", got {method}.'
         )
     if image.ndim == 2 and (method is None or method == 'zhang'):
         skeleton = _skeletonize_zhang(image)
     elif image.ndim == 3 and method == 'zhang':
-        raise ValueError('skeletonize method "zhang" only works for 2D ' 'images.')
+        raise ValueError('skeletonize method "zhang" only works for 2D images.')
     elif image.ndim == 3 or (image.ndim == 2 and method == 'lee'):
         skeleton = _skeletonize_lee(image)
     else:
         raise ValueError(
-            f'skeletonize requires a 2D or 3D image as input, ' f'got {image.ndim}D.'
+            f'skeletonize requires a 2D or 3D image as input, got {image.ndim}D.'
         )
     return skeleton
 

--- a/src/_skimage2/morphology/_skeletonize_various_cy.pyx
+++ b/src/_skimage2/morphology/_skeletonize_various_cy.pyx
@@ -234,6 +234,7 @@ def _table_lookup_index(cnp.uint8_t[:, ::1] image):
         Py_ssize_t j_shape
         Py_ssize_t i
         Py_ssize_t j
+        Py_ssize_t _j
         Py_ssize_t offset
 
     i_shape   = image.shape[0]
@@ -247,7 +248,7 @@ def _table_lookup_index(cnp.uint8_t[:, ::1] image):
     with nogil:
         for i in range(1, i_shape-1):
             offset = i_stride* i + 1
-            for j in range(1, j_shape - 1):
+            for _j in range(1, j_shape - 1):
                 if p_image[offset]:
                     p_indexer[offset + i_stride + 1] += 1
                     p_indexer[offset + i_stride] += 2

--- a/src/_skimage2/morphology/_util.py
+++ b/src/_skimage2/morphology/_util.py
@@ -46,7 +46,7 @@ def _validate_connectivity(image_dim, connectivity, offset):
 
     if offset is None:
         if any([x % 2 == 0 for x in c_connectivity.shape]):
-            raise ValueError("Connectivity array must have an unambiguous " "center")
+            raise ValueError("Connectivity array must have an unambiguous center")
 
         offset = np.array(c_connectivity.shape) // 2
 
@@ -255,9 +255,7 @@ def _resolve_neighborhood(footprint, connectivity, ndim, enforce_adjacency=True)
         footprint = np.asarray(footprint, dtype=bool)
         # Must specify neighbors for all dimensions
         if footprint.ndim != ndim:
-            raise ValueError(
-                "number of dimensions in image and footprint do not" "match"
-            )
+            raise ValueError("number of dimensions in image and footprint do notmatch")
         # Must only specify direct neighbors
         if enforce_adjacency and any(s != 3 for s in footprint.shape):
             raise ValueError("dimension size in footprint is not 3")
@@ -309,7 +307,7 @@ def _set_border_values(image, value, border_width=1):
         raise ValueError('length of `border_width` must match image.ndim')
     for axis, npad in enumerate(border_width):
         if len(npad) != 2:
-            raise ValueError('each sequence in `border_width` must have ' 'length 2')
+            raise ValueError('each sequence in `border_width` must have length 2')
         w_start, w_end = npad
         if w_start == w_end == 0:
             continue

--- a/src/_skimage2/morphology/_util.py
+++ b/src/_skimage2/morphology/_util.py
@@ -121,7 +121,7 @@ def _raveled_offsets_and_distances(
 
     if not footprint.ndim == ndim == len(center):
         raise ValueError(
-            "number of dimensions in image shape, footprint and its"
+            "number of dimensions in image shape, footprint and its "
             "center index does not match"
         )
 
@@ -255,7 +255,7 @@ def _resolve_neighborhood(footprint, connectivity, ndim, enforce_adjacency=True)
         footprint = np.asarray(footprint, dtype=bool)
         # Must specify neighbors for all dimensions
         if footprint.ndim != ndim:
-            raise ValueError("number of dimensions in image and footprint do notmatch")
+            raise ValueError("number of dimensions in image and footprint do not match")
         # Must only specify direct neighbors
         if enforce_adjacency and any(s != 3 for s in footprint.shape):
             raise ValueError("dimension size in footprint is not 3")

--- a/src/_skimage2/morphology/convex_hull.py
+++ b/src/_skimage2/morphology/convex_hull.py
@@ -107,8 +107,7 @@ def convex_hull_image(
     ndim = image.ndim
     if np.count_nonzero(image) == 0:
         warn(
-            "Input image is entirely zero, no valid convex hull. "
-            "Returning empty image",
+            "Input image is entirely zero, no valid convex hull. Returning empty image",
             UserWarning,
         )
         return np.zeros(image.shape, dtype=bool)

--- a/src/_skimage2/morphology/extrema.py
+++ b/src/_skimage2/morphology/extrema.py
@@ -24,7 +24,7 @@ def _add_constant_clip(image, const_value):
 
     if const_value > (max_dtype - min_dtype):
         raise ValueError(
-            "The added constant is not compatiblewith the image data type."
+            "The added constant is not compatible with the image data type."
         )
 
     result = image + const_value
@@ -38,7 +38,7 @@ def _subtract_constant_clip(image, const_value):
 
     if const_value > (max_dtype - min_dtype):
         raise ValueError(
-            "The subtracted constant is not compatiblewith the image data type."
+            "The subtracted constant is not compatible with the image data type."
         )
 
     result = image - const_value

--- a/src/_skimage2/morphology/extrema.py
+++ b/src/_skimage2/morphology/extrema.py
@@ -24,7 +24,7 @@ def _add_constant_clip(image, const_value):
 
     if const_value > (max_dtype - min_dtype):
         raise ValueError(
-            "The added constant is not compatible" "with the image data type."
+            "The added constant is not compatiblewith the image data type."
         )
 
     result = image + const_value
@@ -38,7 +38,7 @@ def _subtract_constant_clip(image, const_value):
 
     if const_value > (max_dtype - min_dtype):
         raise ValueError(
-            "The subtracted constant is not compatible" "with the image data type."
+            "The subtracted constant is not compatiblewith the image data type."
         )
 
     result = image - const_value
@@ -147,7 +147,7 @@ def h_maxima(image, h, footprint=None):
             h = image.dtype.type(h)
 
     if h == 0:
-        raise ValueError("h = 0 is ambiguous, use local_maxima() " "instead?")
+        raise ValueError("h = 0 is ambiguous, use local_maxima() instead?")
 
     if np.issubdtype(image.dtype, np.floating):
         # The purpose of the resolution variable is to allow for the
@@ -257,7 +257,7 @@ def h_minima(image, h, footprint=None):
             h = image.dtype.type(h)
 
     if h == 0:
-        raise ValueError("h = 0 is ambiguous, use local_minima() " "instead?")
+        raise ValueError("h = 0 is ambiguous, use local_minima() instead?")
 
     if np.issubdtype(image.dtype, np.floating):
         resolution = 2 * np.finfo(image.dtype).resolution * np.abs(image)

--- a/src/_skimage2/morphology/misc.py
+++ b/src/_skimage2/morphology/misc.py
@@ -25,7 +25,7 @@ def _check_dtype_supported(ar):
     # Should use `issubdtype` for bool below, but there's a bug in numpy 1.7
     if not (ar.dtype == bool or np.issubdtype(ar.dtype, np.integer)):
         raise TypeError(
-            "Only bool or integer image types are supported. " f"Got {ar.dtype}."
+            f"Only bool or integer image types are supported. Got {ar.dtype}."
         )
 
 

--- a/src/_skimage2/registration/_optical_flow_utils.py
+++ b/src/_skimage2/registration/_optical_flow_utils.py
@@ -130,7 +130,7 @@ def _coarse_to_fine(
         raise ValueError("Input images should have the same shape")
 
     if np.dtype(dtype).char not in 'efdg':
-        raise ValueError("Only floating point data type are valid" " for optical flow")
+        raise ValueError("Only floating point data type are valid for optical flow")
 
     pyramid = list(
         zip(

--- a/src/_skimage2/restoration/_cycle_spin.py
+++ b/src/_skimage2/restoration/_cycle_spin.py
@@ -41,7 +41,7 @@ def _generate_shifts(ndim, multichannel, max_shifts, shift_steps=1):
 
     if multichannel and max_shifts[-1] != 0:
         raise ValueError(
-            "Multichannel cycle spinning should not have shifts along the " "last axis."
+            "Multichannel cycle spinning should not have shifts along the last axis."
         )
 
     return product(*[range(0, s + 1, t) for s, t in zip(max_shifts, shift_steps)])

--- a/src/_skimage2/restoration/_denoise.py
+++ b/src/_skimage2/restoration/_denoise.py
@@ -649,7 +649,7 @@ def _sigma_est_dwt(detail_coeffs, distribution='Gaussian'):
         denom = scipy.stats.norm.ppf(0.75)
         sigma = np.median(np.abs(detail_coeffs)) / denom
     else:
-        raise ValueError("Only Gaussian noise estimation is currently " "supported")
+        raise ValueError("Only Gaussian noise estimation is currently supported")
     return sigma
 
 

--- a/src/_skimage2/restoration/unwrap.py
+++ b/src/_skimage2/restoration/unwrap.py
@@ -88,7 +88,7 @@ def unwrap_phase(image, wrap_around=False, rng=None):
     elif hasattr(wrap_around, '__getitem__') and not isinstance(wrap_around, str):
         if len(wrap_around) != image.ndim:
             raise ValueError(
-                'Length of `wrap_around` must equal the ' 'dimensionality of image'
+                'Length of `wrap_around` must equal the dimensionality of image'
             )
         wrap_around = [bool(wa) for wa in wrap_around]
     else:

--- a/src/_skimage2/segmentation/_chan_vese.py
+++ b/src/_skimage2/segmentation/_chan_vese.py
@@ -325,8 +325,7 @@ def chan_vese(
 
     if type(phi) != np.ndarray or phi.shape != image.shape:
         raise ValueError(
-            "The dimensions of initial level set do not "
-            "match the dimensions of image."
+            "The dimensions of initial level set do not match the dimensions of image."
         )
 
     image = image.astype(float_dtype, copy=False)

--- a/src/_skimage2/segmentation/_felzenszwalb.py
+++ b/src/_skimage2/segmentation/_felzenszwalb.py
@@ -62,7 +62,7 @@ def felzenszwalb(image, scale=1, sigma=0.8, min_size=20, *, channel_axis=-1):
     """
     if channel_axis is None and image.ndim > 2:
         raise ValueError(
-            "This algorithm works only on single or " "multi-channel 2d images. "
+            "This algorithm works only on single or multi-channel 2d images. "
         )
 
     image = np.atleast_3d(image)

--- a/src/_skimage2/segmentation/_felzenszwalb_cy.pyx
+++ b/src/_skimage2/segmentation/_felzenszwalb_cy.pyx
@@ -94,7 +94,7 @@ def _felzenszwalb_cython(image, cnp.float64_t scale=1, sigma=0.8,
 
     # inner cost of segments
     cdef cnp.ndarray[cnp.float64_t, ndim=1] cint = np.zeros(width * height)
-    cdef cnp.intp_t seg0, seg1, seg_new, e
+    cdef cnp.intp_t seg0, seg1, seg_new, _e
     cdef cnp.float32_t inner_cost0, inner_cost1
     cdef Py_ssize_t num_costs = costs.size
 
@@ -102,7 +102,7 @@ def _felzenszwalb_cython(image, cnp.float64_t scale=1, sigma=0.8,
         # set costs_p back one. we increase it before we use it
         # since we might continue before that.
         costs_p -= 1
-        for e in range(num_costs):
+        for _e in range(num_costs):
             seg0 = find_root(segments_p, edges_p[0])
             seg1 = find_root(segments_p, edges_p[1])
             edges_p += 2
@@ -120,7 +120,7 @@ def _felzenszwalb_cython(image, cnp.float64_t scale=1, sigma=0.8,
 
         # postprocessing to remove small segments
         edges_p = <cnp.intp_t*>edges.data
-        for e in range(num_costs):
+        for _e in range(num_costs):
             seg0 = find_root(segments_p, edges_p[0])
             seg1 = find_root(segments_p, edges_p[1])
             edges_p += 2

--- a/src/_skimage2/segmentation/_slic.pyx
+++ b/src/_skimage2/segmentation/_slic.pyx
@@ -107,7 +107,7 @@ def _slic_cython(np_floats[:, :, :, ::1] image_zyx,
         = np.empty((depth, height, width), dtype=dtype)
     cdef Py_ssize_t[::1] n_segment_elems = np.empty(n_segments, dtype=np.intp)
 
-    cdef Py_ssize_t i, c, k, x, y, z, x_min, x_max, y_min, y_max, z_min, z_max
+    cdef Py_ssize_t _i, c, k, x, y, z, x_min, x_max, y_min, y_max, z_min, z_max
     cdef bint change
     cdef np_floats dist_center, cx, cy, cz, dx, dy, dz, t
 
@@ -125,7 +125,7 @@ def _slic_cython(np_floats[:, :, :, ::1] image_zyx,
     cdef np_floats spatial_weight = 1.0 / (step * step)
 
     with nogil:
-        for i in range(max_num_iter):
+        for _i in range(max_num_iter):
             change = False
             distance[:, :, :] = DBL_MAX
 

--- a/src/_skimage2/segmentation/morphsnakes.py
+++ b/src/_skimage2/segmentation/morphsnakes.py
@@ -53,7 +53,7 @@ def sup_inf(u):
     elif np.ndim(u) == 3:
         P = _P3
     else:
-        raise ValueError("u has an invalid number of dimensions " "(should be 2 or 3)")
+        raise ValueError("u has an invalid number of dimensions (should be 2 or 3)")
 
     erosions = []
     for P_i in P:
@@ -70,7 +70,7 @@ def inf_sup(u):
     elif np.ndim(u) == 3:
         P = _P3
     else:
-        raise ValueError("u has an invalid number of dimensions " "(should be 2 or 3)")
+        raise ValueError("u has an invalid number of dimensions (should be 2 or 3)")
 
     dilations = []
     for P_i in P:
@@ -104,7 +104,7 @@ def _init_level_set(init_level_set, image_shape):
         elif init_level_set == 'disk':
             res = disk_level_set(image_shape)
         else:
-            raise ValueError("`init_level_set` not in " "['checkerboard', 'disk']")
+            raise ValueError("`init_level_set` not in ['checkerboard', 'disk']")
     else:
         res = init_level_set
     return res

--- a/src/_skimage2/segmentation/random_walker_segmentation.py
+++ b/src/_skimage2/segmentation/random_walker_segmentation.py
@@ -520,7 +520,7 @@ def random_walker(
     if not multichannel:
         if data.ndim not in (2, 3):
             raise ValueError(
-                'For non-multichannel input, data must be of ' 'dimension 2 or 3.'
+                'For non-multichannel input, data must be of dimension 2 or 3.'
             )
         if data.shape != labels.shape:
             raise ValueError('Incompatible data and labels shapes.')
@@ -528,7 +528,7 @@ def random_walker(
     else:
         if data.ndim not in (3, 4):
             raise ValueError(
-                'For multichannel input, data must have 3 or 4 ' 'dimensions.'
+                'For multichannel input, data must have 3 or 4 dimensions.'
             )
         if data.shape[:-1] != labels.shape:
             raise ValueError('Incompatible data and labels shapes.')

--- a/src/_skimage2/segmentation/slic_superpixels.py
+++ b/src/_skimage2/segmentation/slic_superpixels.py
@@ -384,8 +384,7 @@ def slic(
                 sigma = np.insert(sigma, 0, 0)
         elif sigma.size != 3:
             raise ValueError(
-                f"Input image is 3D, but sigma has "
-                f"{sigma.size} elements (expected 3)."
+                f"Input image is 3D, but sigma has {sigma.size} elements (expected 3)."
             )
 
     if (sigma > 0).any():

--- a/src/_skimage2/transform/_geometric.py
+++ b/src/_skimage2/transform/_geometric.py
@@ -25,9 +25,7 @@ def _affine_matrix_from_vector(v):
     d = (1 + np.sqrt(1 + 4 * nparam)) / 2 - 1
     dimensionality = int(np.round(d))  # round to prevent approx errors
     if d != dimensionality:
-        raise ValueError(
-            'Invalid number of elements for ' f'linearized matrix: {nparam}'
-        )
+        raise ValueError(f'Invalid number of elements for linearized matrix: {nparam}')
     matrix = np.eye(dimensionality + 1)
     matrix[:-1, :] = np.reshape(v, (dimensionality, dimensionality + 1))
     return matrix
@@ -379,8 +377,7 @@ class _HMatrixTransform(_GeometricTransform):
         if dimensionality is not None:
             if dimensionality != matrix.shape[0] - 1:
                 raise ValueError(
-                    f'Dimensionality {dimensionality} does not match matrix '
-                    f'{matrix}'
+                    f'Dimensionality {dimensionality} does not match matrix {matrix}'
                 )
         m = matrix.shape[0]
         if matrix.shape != (m, m):
@@ -834,8 +831,7 @@ class EssentialMatrixTransform(FundamentalMatrixTransform):
         elif n_rt_none == 0:
             if matrix is not None:
                 raise ValueError(
-                    "Do not specify rotation or translation when "
-                    "matrix is specified."
+                    "Do not specify rotation or translation when matrix is specified."
                 )
             matrix = self._rt2matrix(rotation, translation)
         super().__init__(matrix=matrix, dimensionality=dimensionality)
@@ -1487,8 +1483,7 @@ class AffineTransform(ProjectiveTransform):
         if n_srst_none != 4:
             if matrix is not None:
                 raise ValueError(
-                    "Do not specify any implicit parameters when "
-                    "matrix is specified."
+                    "Do not specify any implicit parameters when matrix is specified."
                 )
             if dimensionality is not None and dimensionality > 2:
                 raise ValueError('Implicit parameters only valid for 2D transforms')
@@ -1945,8 +1940,7 @@ class EuclideanTransform(ProjectiveTransform):
         if n_rt_none != 2:
             if matrix is not None:
                 raise ValueError(
-                    "Do not specify any implicit parameters when "
-                    "matrix is specified."
+                    "Do not specify any implicit parameters when matrix is specified."
                 )
             n_dims, chk_msg = self._rt2ndims_msg(rotation, translation)
             if chk_msg is not None:
@@ -2202,8 +2196,7 @@ class SimilarityTransform(EuclideanTransform):
         if n_srt_none != 3:
             if matrix is not None:
                 raise ValueError(
-                    "Do not specify any implicit parameters when "
-                    "matrix is specified."
+                    "Do not specify any implicit parameters when matrix is specified."
                 )
             self._check_scale(scale, (rotation, translation), dimensionality)
             # Scale is special.  Scalar scale does not tell us the dimensions.

--- a/src/_skimage2/transform/_warps.py
+++ b/src/_skimage2/transform/_warps.py
@@ -61,8 +61,7 @@ def _preprocess_resize_output_shape(image, output_shape):
         output_shape = output_shape + (image.shape[-1],)
     elif output_ndim < image.ndim:
         raise ValueError(
-            "output_shape length cannot be smaller than the "
-            "image number of dimensions"
+            "output_shape length cannot be smaller than the image number of dimensions"
         )
 
     return image, output_shape
@@ -322,7 +321,7 @@ def rescale(
         if (not multichannel and len(scale) != image.ndim) or (
             multichannel and len(scale) != image.ndim - 1
         ):
-            raise ValueError("Supply a single scale, or one value per spatial " "axis")
+            raise ValueError("Supply a single scale, or one value per spatial axis")
         if multichannel:
             scale = np.concatenate((scale, [1]))
     orig_shape = np.asarray(image.shape)

--- a/src/_skimage2/transform/radon_transform.py
+++ b/src/_skimage2/transform/radon_transform.py
@@ -72,8 +72,7 @@ def radon(image, theta=None, circle=True, *, preserve_range=False):
         outside_reconstruction_circle = dist > radius**2
         if np.any(image[outside_reconstruction_circle]):
             warn(
-                'Radon transform: image must be zero outside the '
-                'reconstruction circle'
+                'Radon transform: image must be zero outside the reconstruction circle'
             )
         # Crop image to make it square
         slices = tuple(
@@ -479,7 +478,7 @@ def iradon_sart(
             dtype = np.dtype(float)
     elif np.dtype(dtype).char not in 'fd':
         raise ValueError(
-            "Only floating point data type are valid for inverse " "radon transform."
+            "Only floating point data type are valid for inverse radon transform."
         )
 
     dtype = np.dtype(dtype)
@@ -505,7 +504,7 @@ def iradon_sart(
             f'of radon_image ({reconstructed_shape})'
         )
     elif image.dtype != dtype:
-        warn(f'image dtype does not match output dtype: ' f'image is cast to {dtype}')
+        warn(f'image dtype does not match output dtype: image is cast to {dtype}')
 
     image = np.asarray(image, dtype=dtype)
 

--- a/src/_skimage2/util/_label.py
+++ b/src/_skimage2/util/_label.py
@@ -40,7 +40,7 @@ def label_points(coords, output_shape):
     - Negative coordinates raise a ValueError
     """
     if coords.shape[1] != len(output_shape):
-        raise ValueError("Dimensionality of points should match the " "output shape")
+        raise ValueError("Dimensionality of points should match the output shape")
 
     if np.any(coords < 0):
         raise ValueError("Coordinates should be positive and start from 0")

--- a/src/_skimage2/util/_slice_along_axes.py
+++ b/src/_skimage2/util/_slice_along_axes.py
@@ -57,7 +57,7 @@ def slice_along_axes(image, slices, axes=None, copy=False):
 
     if not all(a >= 0 and a < image.ndim for a in axes):
         raise ValueError(
-            f"axes {axes} out of range; image has only " f"{image.ndim} dimensions"
+            f"axes {axes} out of range; image has only {image.ndim} dimensions"
         )
 
     _slices = [

--- a/src/_skimage2/util/apply_parallel.py
+++ b/src/_skimage2/util/apply_parallel.py
@@ -144,7 +144,7 @@ def apply_parallel(
         import dask.array as da
     except ImportError:
         raise RuntimeError(
-            "Could not import 'dask'.  Please install " "using 'pip install dask'"
+            "Could not import 'dask'.  Please install using 'pip install dask'"
         )
 
     if extra_keywords is None:

--- a/src/_skimage2/util/dtype.py
+++ b/src/_skimage2/util/dtype.py
@@ -284,7 +284,7 @@ def _convert(image, dtype, force_copy=False, uniform=False):
         return image
 
     if not (dtype_in in _supported_types and dtype_out in _supported_types):
-        raise ValueError(f'Cannot convert from {dtypeobj_in} to ' f'{dtypeobj_out}.')
+        raise ValueError(f'Cannot convert from {dtypeobj_in} to {dtypeobj_out}.')
 
     if kind_in in 'ui':
         imin_in = np.iinfo(dtype_in).min

--- a/src/_skimage2/util/shape.py
+++ b/src/_skimage2/util/shape.py
@@ -78,7 +78,7 @@ def view_as_blocks(arr_in, block_shape):
         raise ValueError("'block_shape' elements must be strictly positive")
 
     if block_shape.size != arr_in.ndim:
-        raise ValueError("'block_shape' must have the same length " "as 'arr_in.shape'")
+        raise ValueError("'block_shape' must have the same length as 'arr_in.shape'")
 
     arr_shape = np.array(arr_in.shape)
     if (arr_shape % block_shape).sum() != 0:

--- a/src/_skimage2/util/unique.py
+++ b/src/_skimage2/util/unique.py
@@ -37,9 +37,7 @@ def unique_rows(ar):
            [1, 0, 1]], dtype=uint8)
     """
     if ar.ndim != 2:
-        raise ValueError(
-            "unique_rows() only makes sense for 2D arrays, " f"got {ar.ndim}"
-        )
+        raise ValueError(f"unique_rows() only makes sense for 2D arrays, got {ar.ndim}")
     # the view in the next line only works if the array is C-contiguous
     ar = np.ascontiguousarray(ar)
     # np.unique() finds identical items in a raveled array. To make it

--- a/src/skimage/future/trainable_segmentation.py
+++ b/src/skimage/future/trainable_segmentation.py
@@ -46,7 +46,7 @@ class TrainableSegmenter:
                 self.clf = RandomForestClassifier(n_estimators=100, n_jobs=-1)
             else:
                 raise ImportError(
-                    "Please install scikit-learn or pass a classifier instance"
+                    "Please install scikit-learn or pass a classifier instance "
                     "to TrainableSegmenter."
                 )
         else:
@@ -162,7 +162,7 @@ def predict_segmenter(features, clf):
         predicted_labels = clf.predict(features)
     except NotFittedError:
         raise NotFittedError(
-            "You must train the classifier `clf` first"
+            "You must train the classifier `clf` first, "
             "for example with the `fit_segmenter` function."
         )
     except ValueError as err:

--- a/tests/skimage/feature/test_blob.py
+++ b/tests/skimage/feature/test_blob.py
@@ -152,12 +152,12 @@ def test_blob_dog_exclude_border(disc_center, exclude_border):
     if disc_center == (5, 20) and exclude_border == (4, 15):
         assert blobs.shape[0] == 1, "one blob should have been detected"
         b = blobs[0]
-        assert (
-            b[0] == disc_center[0]
-        ), f"blob should be {disc_center[0]} px from x border"
-        assert (
-            b[1] == disc_center[1]
-        ), f"blob should be {disc_center[1]} px from y border"
+        assert b[0] == disc_center[0], (
+            f"blob should be {disc_center[0]} px from x border"
+        )
+        assert b[1] == disc_center[1], (
+            f"blob should be {disc_center[1]} px from y border"
+        )
     else:
         msg = "zero blobs should be detected, as only blob is 5 px from border"
         assert blobs.shape[0] == 0, msg
@@ -324,12 +324,12 @@ def test_blob_log_exclude_border(disc_center, exclude_border):
     if disc_center == (5, 20) and exclude_border == (4, 15):
         assert blobs.shape[0] == 1, "one blob should have been detected"
         b = blobs[0]
-        assert (
-            b[0] == disc_center[0]
-        ), f"blob should be {disc_center[0]} px from x border"
-        assert (
-            b[1] == disc_center[1]
-        ), f"blob should be {disc_center[1]} px from y border"
+        assert b[0] == disc_center[0], (
+            f"blob should be {disc_center[0]} px from x border"
+        )
+        assert b[1] == disc_center[1], (
+            f"blob should be {disc_center[1]} px from y border"
+        )
     else:
         msg = "zero blobs should be detected, as only blob is 5 px from border"
         assert blobs.shape[0] == 0, msg

--- a/tests/skimage/feature/test_hog.py
+++ b/tests/skimage/feature/test_hog.py
@@ -250,7 +250,7 @@ def test_hog_orientations_circle():
             plt.subplot(1, 2, 2)
             plt.imshow(hog_img)
             plt.colorbar()
-            plt.title('HOG result visualisation, ' f'orientations={orientations}')
+            plt.title(f'HOG result visualisation, orientations={orientations}')
             plt.show()
 
         # reshape resulting feature vector to matrix with N columns (each

--- a/tests/skimage/util/test_backends.py
+++ b/tests/skimage/util/test_backends.py
@@ -28,8 +28,7 @@ def fake_backends(monkeypatch):
 
             if not name.endswith(":foo"):
                 raise ValueError(
-                    "Backend only implements the 'foo' function."
-                    f" Called with '{name}'"
+                    f"Backend only implements the 'foo' function. Called with '{name}'"
                 )
 
             return fake_foo
@@ -37,8 +36,7 @@ def fake_backends(monkeypatch):
         def can_has(self, name, *args, **kwargs):
             if not name.endswith(":foo"):
                 raise ValueError(
-                    "Backend only implements the 'foo' function."
-                    f" Called with '{name}'"
+                    f"Backend only implements the 'foo' function. Called with '{name}'"
                 )
             return True
 

--- a/tests/skimage2/feature/test_blob.py
+++ b/tests/skimage2/feature/test_blob.py
@@ -152,12 +152,12 @@ def test_blob_dog_exclude_border(disc_center, exclude_border):
     if disc_center == (5, 20) and exclude_border == (4, 15):
         assert blobs.shape[0] == 1, "one blob should have been detected"
         b = blobs[0]
-        assert (
-            b[0] == disc_center[0]
-        ), f"blob should be {disc_center[0]} px from x border"
-        assert (
-            b[1] == disc_center[1]
-        ), f"blob should be {disc_center[1]} px from y border"
+        assert b[0] == disc_center[0], (
+            f"blob should be {disc_center[0]} px from x border"
+        )
+        assert b[1] == disc_center[1], (
+            f"blob should be {disc_center[1]} px from y border"
+        )
     else:
         msg = "zero blobs should be detected, as only blob is 5 px from border"
         assert blobs.shape[0] == 0, msg
@@ -324,12 +324,12 @@ def test_blob_log_exclude_border(disc_center, exclude_border):
     if disc_center == (5, 20) and exclude_border == (4, 15):
         assert blobs.shape[0] == 1, "one blob should have been detected"
         b = blobs[0]
-        assert (
-            b[0] == disc_center[0]
-        ), f"blob should be {disc_center[0]} px from x border"
-        assert (
-            b[1] == disc_center[1]
-        ), f"blob should be {disc_center[1]} px from y border"
+        assert b[0] == disc_center[0], (
+            f"blob should be {disc_center[0]} px from x border"
+        )
+        assert b[1] == disc_center[1], (
+            f"blob should be {disc_center[1]} px from y border"
+        )
     else:
         msg = "zero blobs should be detected, as only blob is 5 px from border"
         assert blobs.shape[0] == 0, msg

--- a/tests/skimage2/feature/test_hog.py
+++ b/tests/skimage2/feature/test_hog.py
@@ -250,7 +250,7 @@ def test_hog_orientations_circle():
             plt.subplot(1, 2, 2)
             plt.imshow(hog_img)
             plt.colorbar()
-            plt.title('HOG result visualisation, ' f'orientations={orientations}')
+            plt.title(f'HOG result visualisation, orientations={orientations}')
             plt.show()
 
         # reshape resulting feature vector to matrix with N columns (each


### PR DESCRIPTION
Routine `pre-commit autoupdate`, moving the five hook repos to pre-commit-hooks v6.0.0, prettier v3.9.6, ruff v0.16.3, cython-lint v0.21.0, and zizmor v1.29.0. Revisions stay frozen to hashes. Most of the diff is ruff 0.16 rejoining implicit string concatenations.

Three calls worth a reviewer's judgment:

- zizmor 1.29 wants a hash pin on every action, 45 errors that 1.3.0 never raised. `.github/zizmor.yml` keeps version tags for the `actions/*` refs Dependabot tracks and requires hashes elsewhere. 
- cython-lint 0.21 flags unused loop counters, renamed here with a leading underscore. One case in `_sift.pyx` was an inner loop reusing the outer loop's target name; behavior is unchanged.
- Eleven error messages were missing a space where two string literals met, giving text like "Maximum iteration reached for histogramsmoothing". These predate this PR; rejoining the shorter ones is what made them visible. The last commit adds the missing spaces, using a comma or period where two sentences ran together.

### Testing

`pre-commit run --all-files` passes at both the default and manual stages, and the edited `.pyx` files compile under Cython 3.2.9. Comparing every string constant before and after confirms the reformatting itself changed no string values. Nothing in the test suite or docs matches the corrected messages. No test suite run, so CI should be the judge.

### AI disclosure

Written by Claude Opus 5 through Claude Code, with `Assisted-by:` tags on the commits. Needs human review before this leaves draft.

### Release note (optional)

<!-- See https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes -->

```release-note
...
```
