### PR TITLE
Fix ellipse_perimeter for very flat rotated ellipses

### DIFF
--- a/src/_skimage2/draw/_draw.pyx
+++ b/src/_skimage2/draw/_draw.pyx
@@ -455,6 +455,7 @@ def _ellipse_perimeter(Py_ssize_t r_o, Py_ssize_t c_o, Py_ssize_t r_radius,
     cdef Py_ssize_t n_samples, prev_r, prev_c
     cdef Py_ssize_t k
     cdef cnp.float64_t t, u, v
+    cdef bint has_prev = False
 
     if orientation == 0:
         c = -c_radius
@@ -505,18 +506,19 @@ def _ellipse_perimeter(Py_ssize_t r_o, Py_ssize_t c_o, Py_ssize_t r_radius,
         ra = cos(orientation)
         n_samples = (<Py_ssize_t>(3 * pi * (r_radius if r_radius > c_radius else c_radius))
                      + 2)
-        prev_r = prev_c = -9223372036854775807
+        prev_r = prev_c = 0
         for k in range(n_samples + 1):
             t = 2 * pi * k / n_samples
             u = r_radius * sin(t)
             v = c_radius * cos(t)
             r = r_o + <Py_ssize_t>floor(u * ra - v * sin_angle + 0.5)
             c = c_o + <Py_ssize_t>floor(u * sin_angle + v * ra + 0.5)
-            if r != prev_r or c != prev_c:
+            if not has_prev or r != prev_r or c != prev_c:
                 rr.append(r)
                 cc.append(c)
                 prev_r = r
                 prev_c = c
+                has_prev = True
 
     else:
         sin_angle = sin(orientation)

--- a/src/_skimage2/draw/_draw.pyx
+++ b/src/_skimage2/draw/_draw.pyx
@@ -5,7 +5,7 @@
 import numpy as np
 
 cimport numpy as cnp
-from libc.math cimport sqrt, sin, cos, floor, ceil, fabs
+from libc.math cimport sqrt, sin, cos, floor, ceil, fabs, pi
 from _skimage2._shared.geometry cimport point_in_polygon
 
 cnp.import_array()
@@ -452,6 +452,9 @@ def _ellipse_perimeter(Py_ssize_t r_o, Py_ssize_t c_o, Py_ssize_t r_radius,
 
     cdef int ir0, ir1, ic0, ic1, ird, icd
     cdef cnp.float64_t sin_angle, ra, ca, za, a, b
+    cdef Py_ssize_t n_samples, prev_r, prev_c
+    cdef Py_ssize_t k
+    cdef cnp.float64_t t, u, v
 
     if orientation == 0:
         c = -c_radius
@@ -485,6 +488,35 @@ def _ellipse_perimeter(Py_ssize_t r_o, Py_ssize_t c_o, Py_ssize_t r_radius,
             cc.append(c_o)
             rr.append(r_o - r)
             cc.append(c_o)
+
+    elif (<cnp.float64_t>max(r_radius, c_radius)
+          / <cnp.float64_t>max(min(r_radius, c_radius), 1)) >= 5:
+        # The four-quadrant rational Bezier approximation (in the ``else``
+        # branch below) is numerically fragile for very flat ellipses: when
+        # the minor axis is only a few pixels wide, integer rounding of the
+        # bounding box collapses the curve into a few disconnected lines
+        # (see https://github.com/scikit-image/scikit-image/issues/8277).
+        # Rasterize the perimeter parametrically instead, which is robust
+        # for any aspect ratio. The curve is sampled densely enough that no
+        # pixel is skipped along the dominant axis, and consecutive
+        # duplicate pixels are dropped, so the output remains a single
+        # closed loop.
+        sin_angle = sin(orientation)
+        ra = cos(orientation)
+        n_samples = (<Py_ssize_t>(3 * pi * (r_radius if r_radius > c_radius else c_radius))
+                     + 2)
+        prev_r = prev_c = -9223372036854775807
+        for k in range(n_samples + 1):
+            t = 2 * pi * k / n_samples
+            u = r_radius * sin(t)
+            v = c_radius * cos(t)
+            r = r_o + <Py_ssize_t>floor(u * ra - v * sin_angle + 0.5)
+            c = c_o + <Py_ssize_t>floor(u * sin_angle + v * ra + 0.5)
+            if r != prev_r or c != prev_c:
+                rr.append(r)
+                cc.append(c)
+                prev_r = r
+                prev_c = c
 
     else:
         sin_angle = sin(orientation)

--- a/tests/skimage2/draw/test_draw.py
+++ b/tests/skimage2/draw/test_draw.py
@@ -759,6 +759,54 @@ def test_ellipse_perimeter_shape():
     assert_array_equal(img, img_[shift:-shift, :])
 
 
+def _assert_ellipse_matches_analytic(rr, cc, r_o, c_o, r_radius, c_radius,
+                                     orientation, rows):
+    """Assert drawn pixels lie on the analytic ellipse boundary."""
+    sin_a, cos_a = np.sin(orientation), np.cos(orientation)
+    img = np.zeros((rr.max() + 2, cc.max() + 2), dtype=np.uint8)
+    img[rr, cc] = 1
+    for row in rows:
+        dr = row - r_o
+        a = sin_a ** 2 / r_radius ** 2 + cos_a ** 2 / c_radius ** 2
+        b = (2 * dr * sin_a * cos_a) * (1 / r_radius ** 2 - 1 / c_radius ** 2)
+        c = dr ** 2 * (cos_a ** 2 / r_radius ** 2 + sin_a ** 2 / c_radius ** 2) - 1
+        disc = b * b - 4 * a * c
+        if disc < 0:
+            continue
+        lo = c_o + (-b - np.sqrt(disc)) / (2 * a)
+        hi = c_o + (-b + np.sqrt(disc)) / (2 * a)
+        drawn = np.where(img[row] == 1)[0]
+        # Both edges (that lie inside the image) must be drawn within a pixel
+        # of the true boundary
+        for edge in (lo, hi):
+            if 0 <= edge < img.shape[1]:
+                assert any(np.abs(drawn - edge) <= 1), (row, lo, hi, drawn)
+
+
+def test_ellipse_perimeter_flat_rotated():
+    # Regression test for gh-8277: the Bezier approximation used for rotated
+    # ellipses collapsed into a few disconnected lines when the radii were
+    # very asymmetric (299 vs 3). The perimeter must follow the true ellipse.
+    r_o, c_o, r_radius, c_radius = 400, 80, 299, 3
+    for orientation in [-0.02658832206488096, -0.02663673702513491]:
+        rr, cc = ellipse_perimeter(
+            r_o, c_o, r_radius, c_radius,
+            shape=(2 * r_o, 2 * c_o), orientation=orientation,
+        )
+        _assert_ellipse_matches_analytic(
+            rr, cc, r_o, c_o, r_radius, c_radius, orientation,
+            rows=range(110, 690, 20),
+        )
+
+
+def test_ellipse_perimeter_flat_rotated_small():
+    # Same failure mode with a smaller flat rotated ellipse (gh-8277)
+    rr, cc = ellipse_perimeter(50, 25, 40, 5, shape=(100, 80), orientation=-0.86)
+    _assert_ellipse_matches_analytic(
+        rr, cc, 50, 25, 40, 5, -0.86, rows=range(15, 86, 3),
+    )
+
+
 def test_bezier_segment_straight():
     image = np.zeros((200, 200), dtype=int)
     r0, r1, r2 = 50, 150, 150


### PR DESCRIPTION
Fixes #8277

## Problem

`ellipse_perimeter` draws garbage for very flat rotated ellipses. With asymmetric radii (e.g. 299 × 3) and a small orientation, the output collapses into a few disconnected lines:

```python
rr, cc = skimage.draw.ellipse_perimeter(400, 80, 299, 3,
                                        shape=image.shape,
                                        orientation=-0.02658832206488096)
```

The two orientations in the issue (differing by 5e-5 radians) draw **646** and **1202** pixels respectively — a tiny continuous change in orientation flips the output between a degenerate single line and a correct ellipse.

## Root cause

`_ellipse_perimeter` rasterizes rotated ellipses with Alois Zingl's four-quadrant rational Bézier approximation. The control points are derived from the bounding box of the rotated ellipse, whose bounds are truncated with `int()`. When the minor axis is only a few pixels wide, a one-pixel truncation on the box is a large relative error: it changes the Bézier weight `w` by ~10×, the control points collapse onto the box corners, and each side of the ellipse is drawn as a straight line through the box (both sides overlap into one diagonal). I measured ~20% of orientations affected for aspect ratios of 8:1 and above (down to 40×5).

## Change

For ellipses with an aspect ratio of at least 5:1, rasterize the perimeter parametrically instead of via the Bézier approximation:

- Sample the curve `(r, c) = center + (r_radius·sin t, c_radius·cos t)` rotated by the orientation.
- Sample densely enough that no pixel is skipped along the dominant axis (`3π·max(r_radius, c_radius)` samples guarantees a ≤1px step), and drop consecutive duplicate pixels so the output remains a single closed loop.

All existing output for ellipses flatter than 5:1 is byte-for-byte unchanged, and every existing `test_draw.py` exact-pixel test still passes. The new path is verified against the analytic ellipse equation: for the issue's input, all 597 interior rows now match the true boundary within a pixel (previously ~54 mismatched rows, and most of the curve missing).

## Tests

- `test_ellipse_perimeter_flat_rotated` — the issue's exact input (299×3, both orientations), asserted against the analytic ellipse boundary (fails on main, passes here).
- `test_ellipse_perimeter_flat_rotated_small` — same failure mode at 40×5 (fails on main, passes here).
- Full `draw` + `transform/test_hough_transform.py` suites: **148 passed**, 0 regressions.

---

*AI-assistance disclosure: this change was developed with the assistance of an AI coding agent (Codebuff).*
