### PR TITLE
Return sparse arrays from `skimage2.graph` and `skimage2.metrics`

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -45,7 +45,8 @@ Other
   `skimage/graph/_graph_cut.py::_ncut_relabel` and the `xfail` mark in
   `tests/skimage/graph/test_rag.py::test_reproducibility`.
 * Once SciPy 1.18 is minimal required version, remove minkowski
-  distance branching from `src/skimage/measure/fit.py`.
+  distance branching from `src/skimage/measure/fit.py`.  Also remove "dok_matrix"
+  workaround in "test_random" in `tests/skimage2/morphology/test_misc.py`.
 
 Post Python 3.12
 ----------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,27 +222,27 @@ testpaths = [
 
 log_cli_level = "INFO"
 xfail_strict = true
-# filterwarnings = [
-#     "error",
-#     "ignore::skimage.util.PendingSkimage2Change",
-#     "ignore:.*use `imageio` or other I/O packages directly.*:FutureWarning",
-#     # Passing win_size with gaussian_weights=True is deprecated
-#     "ignore:.*win_size.*gaussian_weights.*:FutureWarning",
-#     # warn by pyamg in ruge_stuben_solver
-#     "ignore:Implicit conversion of A to CSR:scipy.sparse.SparseEfficiencyWarning",
-#     # Pyodide warning coming via threadpoolctl, remove when
-#     # https://github.com/joblib/threadpoolctl/pull/201 is released
-#     "ignore:.*JsProxy\\.as_object_map.*:RuntimeWarning",
-#     # Warning caused by matplotlib 3.7.0 because it uses deprecated API of pyparsing 3.3.1
-#     "ignore:.*(parseString|resetCache|enablePackrat|oneOf).*:DeprecationWarning:matplotlib",
-#     # tifffile (v2025.12.20) uses deprecated NumPy API
-#     "ignore:Setting the shape on a NumPy array:DeprecationWarning:tifffile",
-#     # SimpleITK (< 3.0) uses deprecated NumPy API; fixed in SimpleITK 3.0
-#     # TODO: remove once SimpleITK >= 3.0 is required
-#     "ignore:Setting the shape on a NumPy array:DeprecationWarning:SimpleITK",
-#     # pytest warning when running under PYTHONOPTIMIZE=2 (assertions are stripped)
-#     "ignore:assertions not in test modules or plugins:pytest.PytestConfigWarning",
-# ]
+filterwarnings = [
+    "error",
+    "ignore::skimage.util.PendingSkimage2Change",
+    "ignore:.*use `imageio` or other I/O packages directly.*:FutureWarning",
+    # Passing win_size with gaussian_weights=True is deprecated
+    "ignore:.*win_size.*gaussian_weights.*:FutureWarning",
+    # warn by pyamg in ruge_stuben_solver
+    "ignore:Implicit conversion of A to CSR:scipy.sparse.SparseEfficiencyWarning",
+    # Pyodide warning coming via threadpoolctl, remove when
+    # https://github.com/joblib/threadpoolctl/pull/201 is released
+    "ignore:.*JsProxy\\.as_object_map.*:RuntimeWarning",
+    # Warning caused by matplotlib 3.7.0 because it uses deprecated API of pyparsing 3.3.1
+    "ignore:.*(parseString|resetCache|enablePackrat|oneOf).*:DeprecationWarning:matplotlib",
+    # tifffile (v2025.12.20) uses deprecated NumPy API
+    "ignore:Setting the shape on a NumPy array:DeprecationWarning:tifffile",
+    # SimpleITK (< 3.0) uses deprecated NumPy API; fixed in SimpleITK 3.0
+    # TODO: remove once SimpleITK >= 3.0 is required
+    "ignore:Setting the shape on a NumPy array:DeprecationWarning:SimpleITK",
+    # pytest warning when running under PYTHONOPTIMIZE=2 (assertions are stripped)
+    "ignore:assertions not in test modules or plugins:pytest.PytestConfigWarning",
+]
 norecursedirs = ["io/_plugins"]
 
 [tool.changelist]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,27 +222,27 @@ testpaths = [
 
 log_cli_level = "INFO"
 xfail_strict = true
-filterwarnings = [
-    "error",
-    "ignore::skimage.util.PendingSkimage2Change",
-    "ignore:.*use `imageio` or other I/O packages directly.*:FutureWarning",
-    # Passing win_size with gaussian_weights=True is deprecated
-    "ignore:.*win_size.*gaussian_weights.*:FutureWarning",
-    # warn by pyamg in ruge_stuben_solver
-    "ignore:Implicit conversion of A to CSR:scipy.sparse.SparseEfficiencyWarning",
-    # Pyodide warning coming via threadpoolctl, remove when
-    # https://github.com/joblib/threadpoolctl/pull/201 is released
-    "ignore:.*JsProxy\\.as_object_map.*:RuntimeWarning",
-    # Warning caused by matplotlib 3.7.0 because it uses deprecated API of pyparsing 3.3.1
-    "ignore:.*(parseString|resetCache|enablePackrat|oneOf).*:DeprecationWarning:matplotlib",
-    # tifffile (v2025.12.20) uses deprecated NumPy API
-    "ignore:Setting the shape on a NumPy array:DeprecationWarning:tifffile",
-    # SimpleITK (< 3.0) uses deprecated NumPy API; fixed in SimpleITK 3.0
-    # TODO: remove once SimpleITK >= 3.0 is required
-    "ignore:Setting the shape on a NumPy array:DeprecationWarning:SimpleITK",
-    # pytest warning when running under PYTHONOPTIMIZE=2 (assertions are stripped)
-    "ignore:assertions not in test modules or plugins:pytest.PytestConfigWarning",
-]
+# filterwarnings = [
+#     "error",
+#     "ignore::skimage.util.PendingSkimage2Change",
+#     "ignore:.*use `imageio` or other I/O packages directly.*:FutureWarning",
+#     # Passing win_size with gaussian_weights=True is deprecated
+#     "ignore:.*win_size.*gaussian_weights.*:FutureWarning",
+#     # warn by pyamg in ruge_stuben_solver
+#     "ignore:Implicit conversion of A to CSR:scipy.sparse.SparseEfficiencyWarning",
+#     # Pyodide warning coming via threadpoolctl, remove when
+#     # https://github.com/joblib/threadpoolctl/pull/201 is released
+#     "ignore:.*JsProxy\\.as_object_map.*:RuntimeWarning",
+#     # Warning caused by matplotlib 3.7.0 because it uses deprecated API of pyparsing 3.3.1
+#     "ignore:.*(parseString|resetCache|enablePackrat|oneOf).*:DeprecationWarning:matplotlib",
+#     # tifffile (v2025.12.20) uses deprecated NumPy API
+#     "ignore:Setting the shape on a NumPy array:DeprecationWarning:tifffile",
+#     # SimpleITK (< 3.0) uses deprecated NumPy API; fixed in SimpleITK 3.0
+#     # TODO: remove once SimpleITK >= 3.0 is required
+#     "ignore:Setting the shape on a NumPy array:DeprecationWarning:SimpleITK",
+#     # pytest warning when running under PYTHONOPTIMIZE=2 (assertions are stripped)
+#     "ignore:assertions not in test modules or plugins:pytest.PytestConfigWarning",
+# ]
 norecursedirs = ["io/_plugins"]
 
 [tool.changelist]

--- a/src/_skimage2/graph/_graph.py
+++ b/src/_skimage2/graph/_graph.py
@@ -38,7 +38,6 @@ def pixel_graph(
     edge_function=None,
     connectivity=1,
     spacing=None,
-    sparse_type="matrix",
 ):
     """Create an adjacency graph of pixels in an image.
 
@@ -69,16 +68,12 @@ def pixel_graph(
         `scipy.ndimage.generate_binary_structure` for details.
     spacing : tuple of float
         The spacing between pixels along each axis.
-    sparse_type : {"matrix", "array"}, optional
-        The return type of `graph`, either `scipy.sparse.csr_array` or
-        `scipy.sparse.csr_matrix` (default).
 
     Returns
     -------
-    graph : scipy.sparse.csr_matrix or scipy.sparse.csr_array
+    graph : scipy.sparse.csr_array
         A sparse adjacency matrix in which entry (i, j) is 1 if nodes i and j
-        are neighbors, 0 otherwise. Depending on `sparse_type`, this can be
-        returned as a `scipy.sparse.csr_array`.
+        are neighbors, 0 otherwise.
     nodes : array of int
         The nodes of the graph. These correspond to the raveled indices of the
         nonzero pixels in the mask.
@@ -150,12 +145,6 @@ def pixel_graph(
     graph = sparse.csr_array(
         (data, (indices_sequential, neighbor_indices_sequential)), shape=(m, m)
     )
-
-    if sparse_type == "matrix":
-        graph = sparse.csr_matrix(graph)
-    elif sparse_type != "array":
-        msg = f"`sparse_type` must be 'array' or 'matrix', got {sparse_type}"
-        raise ValueError(msg)
 
     return graph, nodes
 

--- a/src/_skimage2/graph/_graph.py
+++ b/src/_skimage2/graph/_graph.py
@@ -157,17 +157,17 @@ def central_pixel(graph, nodes=None, shape=None, partition_size=100):
 
     Parameters
     ----------
-    graph : scipy.sparse.csr_array or scipy.sparse.csr_matrix
+    graph : scipy.sparse.csr_array
         The sparse representation of the graph.
-    nodes : array of int
+    nodes : array of int, optional
         The raveled index of each node in graph in the image. If not provided,
         the returned value will be the index in the input graph.
-    shape : tuple of int
+    shape : tuple of int, optional
         The shape of the image in which the nodes are embedded. If provided,
         the returned coordinates are a NumPy multi-index of the same
         dimensionality as the input shape. Otherwise, the returned coordinate
         is the raveled index provided in `nodes`.
-    partition_size : int
+    partition_size : int, optional
         This function computes the shortest path distance between every pair
         of nodes in the graph. This can result in a very large (N*N) matrix.
         As a simple performance tweak, the distance values are computed in

--- a/src/_skimage2/metrics/_adapted_rand_error.py
+++ b/src/_skimage2/metrics/_adapted_rand_error.py
@@ -74,7 +74,6 @@ def adapted_rand_error(
             image_test,
             ignore_labels=ignore_labels,
             normalize=False,
-            sparse_type="array",
         )
     else:
         p_ij = table

--- a/src/_skimage2/metrics/_contingency_table.py
+++ b/src/_skimage2/metrics/_contingency_table.py
@@ -4,9 +4,7 @@ import numpy as np
 __all__ = ['contingency_table']
 
 
-def contingency_table(
-    im_true, im_test, *, ignore_labels=None, normalize=False, sparse_type="matrix"
-):
+def contingency_table(im_true, im_test, *, ignore_labels=None, normalize=False):
     """
     Return the contingency table for all regions in matched segmentations.
 
@@ -21,16 +19,12 @@ def contingency_table(
         values will not be counted in the score.
     normalize : bool
         Determines if the contingency table is normalized by pixel count.
-    sparse_type : {"matrix", "array"}, optional
-        The return type of `cont`, either `scipy.sparse.csr_array` or
-        `scipy.sparse.csr_matrix` (default).
 
     Returns
     -------
-    cont : scipy.sparse.csr_matrix or scipy.sparse.csr_array
+    cont : scipy.sparse.csr_array
         A contingency table. `cont[i, j]` will equal the number of voxels
-        labeled `i` in `im_true` and `j` in `im_test`. Depending on `sparse_type`,
-        this can be returned as a `scipy.sparse.csr_array`.
+        labeled `i` in `im_true` and `j` in `im_test`.
     """
 
     if ignore_labels is None:
@@ -41,11 +35,5 @@ def contingency_table(
     if normalize:
         data /= np.count_nonzero(data)
     cont = sparse.csr_array((data, (im_true_r, im_test_r)))
-
-    if sparse_type == "matrix":
-        cont = sparse.csr_matrix(cont)
-    elif sparse_type != "array":
-        msg = f"`sparse_type` must be 'array' or 'matrix', got {sparse_type}"
-        raise ValueError(msg)
 
     return cont

--- a/src/skimage/graph/_graph.py
+++ b/src/skimage/graph/_graph.py
@@ -1,13 +1,108 @@
 from _skimage2.graph._graph import (
     central_pixel as central_pixel,
-    pixel_graph as pixel_graph,
 )  # noqa: F401
+
+import scipy.sparse as sparse
+
+import _skimage2 as ski2
+
+from .._migration import ski2_migration_decorator
 
 __all__ = [
     'central_pixel',
     'pixel_graph',
 ]
 
-from skimage._doctest_adapters import adapt_doctests
+
+@ski2_migration_decorator(
+    """\
+    ``%(qname_old)s`` is deprecated in favor of
+    ``%(qname_new)s`` with new behavior:
+
+    * Parameter `sparse_type` was removed
+    * `graph` is always a `scipy.sparse.csr_array`
+
+    SciPy 2.0 deprecates the sparse matrix classes and will remove them no
+    earlier than SciPy 2.2. The two types define ``*`` differently: matrix
+    multiplication for `scipy.sparse.csr_matrix`, elementwise multiplication
+    for `scipy.sparse.csr_array`. ``@`` is matrix multiplication for both.
+
+    To keep the old (``skimage``, v1.x) behavior, convert the result::
+
+        graph, nodes = skimage2.graph.pixel_graph(image, ...)
+        graph = scipy.sparse.csr_matrix(graph)
+    """,
+    qname_old="skimage.graph.pixel_graph",
+)
+def pixel_graph(
+    image,
+    *,
+    mask=None,
+    edge_function=None,
+    connectivity=1,
+    spacing=None,
+    sparse_type="matrix",
+):
+    """Create an adjacency graph of pixels in an image.
+
+    Pixels where the mask is True are nodes in the returned graph, and they are
+    connected by edges to their neighbors according to the connectivity
+    parameter. By default, the *value* of an edge when a mask is given, or when
+    the image is itself the mask, is the Euclidean distance between the pixels.
+
+    However, if an int- or float-valued image is given with no mask, the value
+    of the edges is the absolute difference in intensity between adjacent
+    pixels, weighted by the Euclidean distance.
+
+    Parameters
+    ----------
+    image : array
+        The input image. If the image is of type bool, it will be used as the
+        mask as well.
+    mask : array of bool
+        Which pixels to use. If None, the graph for the whole image is used.
+    edge_function : callable
+        A function taking an array of pixel values, and an array of neighbor
+        pixel values, and an array of distances, and returning a value for the
+        edge. If no function is given, the value of an edge is just the
+        distance.
+    connectivity : int
+        The square connectivity of the pixel neighborhood: the number of
+        orthogonal steps allowed to consider a pixel a neighbor. See
+        `scipy.ndimage.generate_binary_structure` for details.
+    spacing : tuple of float
+        The spacing between pixels along each axis.
+    sparse_type : {"matrix", "array"}, optional
+        The return type of `graph`, either `scipy.sparse.csr_array` or
+        `scipy.sparse.csr_matrix` (default).
+
+    Returns
+    -------
+    graph : scipy.sparse.csr_matrix or scipy.sparse.csr_array
+        A sparse adjacency matrix in which entry (i, j) is 1 if nodes i and j
+        are neighbors, 0 otherwise. Depending on `sparse_type`, this can be
+        returned as a `scipy.sparse.csr_array`.
+    nodes : array of int
+        The nodes of the graph. These correspond to the raveled indices of the
+        nonzero pixels in the mask.
+    """
+    if sparse_type not in ("array", "matrix"):
+        msg = f"`sparse_type` must be 'array' or 'matrix', got {sparse_type}"
+        raise ValueError(msg)
+
+    graph, nodes = ski2.graph.pixel_graph(
+        image,
+        mask=mask,
+        edge_function=edge_function,
+        connectivity=connectivity,
+        spacing=spacing,
+    )
+    if sparse_type == "matrix":
+        graph = sparse.csr_matrix(graph)
+
+    return graph, nodes
+
+
+from skimage._doctest_adapters import adapt_doctests  # noqa: E402
 
 adapt_doctests(globals())

--- a/src/skimage/graph/_graph.py
+++ b/src/skimage/graph/_graph.py
@@ -20,7 +20,7 @@ __all__ = [
     ``%(qname_new)s`` with new behavior:
 
     * Parameter `sparse_type` was removed
-    * `graph` is always a `scipy.sparse.csr_array`
+    * Returned `graph` is always a `scipy.sparse.csr_array`
 
     SciPy 2.0 deprecates the sparse matrix classes and will remove them no
     earlier than SciPy 2.2. The two types define ``*`` differently: matrix

--- a/src/skimage/graph/_graph.py
+++ b/src/skimage/graph/_graph.py
@@ -13,6 +13,10 @@ __all__ = [
     'pixel_graph',
 ]
 
+from skimage._doctest_adapters import adapt_doctests  # noqa: E402
+
+adapt_doctests(globals())
+
 
 @ski2_migration_decorator(
     """\
@@ -101,8 +105,3 @@ def pixel_graph(
         graph = sparse.csr_matrix(graph)
 
     return graph, nodes
-
-
-from skimage._doctest_adapters import adapt_doctests  # noqa: E402
-
-adapt_doctests(globals())

--- a/src/skimage/metrics/_contingency_table.py
+++ b/src/skimage/metrics/_contingency_table.py
@@ -13,7 +13,7 @@ __all__ = ['contingency_table']
     ``%(qname_new)s`` with new behavior:
 
     * Parameter `sparse_type` was removed
-    * `cont` is always a `scipy.sparse.csr_array`
+    * Returned `cont` is always a `scipy.sparse.csr_array`
 
     SciPy 2.0 deprecates the sparse matrix classes and will remove them no
     earlier than SciPy 2.2. The two types define ``*`` differently: matrix

--- a/src/skimage/metrics/_contingency_table.py
+++ b/src/skimage/metrics/_contingency_table.py
@@ -1,7 +1,76 @@
-from _skimage2.metrics._contingency_table import contingency_table as contingency_table  # noqa: F401
+import scipy.sparse as sparse
+
+import _skimage2 as ski2
+
+from .._migration import ski2_migration_decorator
 
 __all__ = ['contingency_table']
 
-from skimage._doctest_adapters import adapt_doctests
+
+@ski2_migration_decorator(
+    """\
+    ``%(qname_old)s`` is deprecated in favor of
+    ``%(qname_new)s`` with new behavior:
+
+    * Parameter `sparse_type` was removed
+    * `cont` is always a `scipy.sparse.csr_array`
+
+    SciPy 2.0 deprecates the sparse matrix classes and will remove them no
+    earlier than SciPy 2.2. The two types define ``*`` differently: matrix
+    multiplication for `scipy.sparse.csr_matrix`, elementwise multiplication
+    for `scipy.sparse.csr_array`. ``@`` is matrix multiplication for both.
+
+    To keep the old (``skimage``, v1.x) behavior, convert the result::
+
+        cont = skimage2.metrics.contingency_table(im_true, im_test, ...)
+        cont = scipy.sparse.csr_matrix(cont)
+    """,
+    qname_old="skimage.metrics.contingency_table",
+)
+def contingency_table(
+    im_true, im_test, *, ignore_labels=None, normalize=False, sparse_type="matrix"
+):
+    """
+    Return the contingency table for all regions in matched segmentations.
+
+    Parameters
+    ----------
+    im_true : ndarray of int
+        Ground-truth label image, same shape as im_test.
+    im_test : ndarray of int
+        Test image.
+    ignore_labels : sequence of int, optional
+        Labels to ignore. Any part of the true image labeled with any of these
+        values will not be counted in the score.
+    normalize : bool
+        Determines if the contingency table is normalized by pixel count.
+    sparse_type : {"matrix", "array"}, optional
+        The return type of `cont`, either `scipy.sparse.csr_array` or
+        `scipy.sparse.csr_matrix` (default).
+
+    Returns
+    -------
+    cont : scipy.sparse.csr_matrix or scipy.sparse.csr_array
+        A contingency table. `cont[i, j]` will equal the number of voxels
+        labeled `i` in `im_true` and `j` in `im_test`. Depending on `sparse_type`,
+        this can be returned as a `scipy.sparse.csr_array`.
+    """
+    if sparse_type not in ("array", "matrix"):
+        msg = f"`sparse_type` must be 'array' or 'matrix', got {sparse_type}"
+        raise ValueError(msg)
+
+    cont = ski2.metrics.contingency_table(
+        im_true,
+        im_test,
+        ignore_labels=ignore_labels,
+        normalize=normalize,
+    )
+    if sparse_type == "matrix":
+        cont = sparse.csr_matrix(cont)
+
+    return cont
+
+
+from skimage._doctest_adapters import adapt_doctests  # noqa: E402
 
 adapt_doctests(globals())

--- a/tests/skimage/graph/test_pixel_graph.py
+++ b/tests/skimage/graph/test_pixel_graph.py
@@ -7,7 +7,20 @@ from skimage.graph._graph import pixel_graph, central_pixel
 mask = np.array([[1, 0, 0], [0, 1, 1], [0, 1, 0]], dtype=bool)
 image = np.random.RandomState(3224015571).random(mask.shape)
 
+# SciPy >= 2.0 deprecates the sparse matrix classes in favor of sparse arrays.
+# The legacy ``skimage`` namespace keeps returning a `scipy.sparse.csr_matrix`
+# by default, so these tests have to tolerate that warning. In ``skimage2`` the
+# default is ``sparse_type="array"``.
+ignore_spmatrix_deprecation = pytest.mark.filterwarnings(
+    "ignore:.*_matrix is being replaced by .*_array:DeprecationWarning"
+)
+sparse_types = [
+    pytest.param("matrix", marks=ignore_spmatrix_deprecation),
+    "array",
+]
 
+
+@ignore_spmatrix_deprecation
 def test_small_graph():
     g, n = pixel_graph(mask, connectivity=2)
     assert g.shape == (4, 4)
@@ -16,6 +29,7 @@ def test_small_graph():
     np.testing.assert_array_equal(n, [0, 4, 5, 7])
 
 
+@ignore_spmatrix_deprecation
 def test_pixel_graph_return_type():
     g, n = pixel_graph(mask, connectivity=2)
     assert isinstance(g, sp.sparse.csr_matrix)
@@ -30,7 +44,7 @@ def test_pixel_graph_return_type():
         pixel_graph(mask, connectivity=2, sparse_type="unknown")
 
 
-@pytest.mark.parametrize("sparse_type", ["matrix", "array"])
+@pytest.mark.parametrize("sparse_type", sparse_types)
 def test_central_pixel(sparse_type):
     g, n = pixel_graph(mask, connectivity=2, sparse_type=sparse_type)
     px, ds = central_pixel(g, n, shape=mask.shape)
@@ -47,7 +61,7 @@ def test_central_pixel(sparse_type):
     assert px == 1
 
 
-@pytest.mark.parametrize("sparse_type", ["matrix", "array"])
+@pytest.mark.parametrize("sparse_type", sparse_types)
 def test_edge_function(sparse_type):
     def edge_func(values_src, values_dst, distances):
         return np.abs(values_src - values_dst) + distances
@@ -65,7 +79,7 @@ def test_edge_function(sparse_type):
     np.testing.assert_array_equal(n, [0, 4, 5, 7])
 
 
-@pytest.mark.parametrize("sparse_type", ["matrix", "array"])
+@pytest.mark.parametrize("sparse_type", sparse_types)
 def test_default_edge_func(sparse_type):
     g, n = pixel_graph(image, spacing=np.array([0.78, 0.78]), sparse_type=sparse_type)
     num_edges = len(g.data) // 2  # each edge appears in both directions
@@ -74,7 +88,7 @@ def test_default_edge_func(sparse_type):
     np.testing.assert_array_equal(n, np.arange(image.size))
 
 
-@pytest.mark.parametrize("sparse_type", ["matrix", "array"])
+@pytest.mark.parametrize("sparse_type", sparse_types)
 def test_no_mask_with_edge_func(sparse_type):
     """Ensure function `pixel_graph` runs when passing `edge_function` but not `mask`."""
     image = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])

--- a/tests/skimage/metrics/test_segmentation_metrics.py
+++ b/tests/skimage/metrics/test_segmentation_metrics.py
@@ -15,7 +15,20 @@ from _skimage2._shared.testing import (
 )
 
 
-@pytest.mark.parametrize("sparse_type", ["matrix", "array"])
+# SciPy >= 2.0 deprecates the sparse matrix classes in favor of sparse arrays.
+# The legacy ``skimage`` namespace keeps returning a `scipy.sparse.csr_matrix`
+# by default, so these tests have to tolerate that warning. In ``skimage2`` the
+# default is ``sparse_type="array"``.
+ignore_spmatrix_deprecation = pytest.mark.filterwarnings(
+    "ignore:.*_matrix is being replaced by .*_array:DeprecationWarning"
+)
+sparse_types = [
+    pytest.param("matrix", marks=ignore_spmatrix_deprecation),
+    "array",
+]
+
+
+@pytest.mark.parametrize("sparse_type", sparse_types)
 def test_contingency_table(sparse_type):
     im_true = np.array([1, 2, 3, 4])
     im_test = np.array([1, 1, 8, 8])
@@ -37,6 +50,7 @@ def test_contingency_table(sparse_type):
     assert_array_equal(table1, table2)
 
 
+@ignore_spmatrix_deprecation
 def test_contingency_table_sparse_type():
     im_true = np.array([1, 2, 3, 4])
     im_test = np.array([1, 1, 8, 8])

--- a/tests/skimage/morphology/test_misc.py
+++ b/tests/skimage/morphology/test_misc.py
@@ -433,18 +433,16 @@ class Test_remove_near_objects:
             np.array(np.nonzero(spaced_objects), dtype=np.float64).transpose(),
         )
 
-        # Compute distance between all objects that are equal or smaller `distance`
-        distances = kdtree.sparse_distance_matrix(
-            kdtree, max_distance=distance, p=p_norm
-        )
+        # Find all pairs of objects that are `distance` apart or closer.
+        # Not sparse_distance_matrix: it builds a coo_matrix internally, which
+        # SciPy 2.0 deprecates (https://github.com/scipy/scipy/issues/25943).
+        pairs = kdtree.query_pairs(r=distance, p=p_norm)
         # There should be no objects left
-        assert distances.count_nonzero() == 0
+        assert len(pairs) == 0
 
         # But increasing by 1 should reveal a few objects
-        distances = kdtree.sparse_distance_matrix(
-            kdtree, max_distance=distance + 1, p=p_norm
-        )
-        assert distances.count_nonzero() > 0
+        pairs = kdtree.query_pairs(r=distance + 1, p=p_norm)
+        assert len(pairs) > 0
 
     @pytest.mark.parametrize("value", [0, 1])
     @pytest.mark.parametrize("dtype", supported_dtypes)

--- a/tests/skimage2/graph/test_pixel_graph.py
+++ b/tests/skimage2/graph/test_pixel_graph.py
@@ -1,6 +1,5 @@
 import numpy as np
 import scipy as sp
-import pytest
 
 from _skimage2.graph._graph import pixel_graph, central_pixel
 
@@ -18,21 +17,11 @@ def test_small_graph():
 
 def test_pixel_graph_return_type():
     g, n = pixel_graph(mask, connectivity=2)
-    assert isinstance(g, sp.sparse.csr_matrix)
-
-    g, n = pixel_graph(mask, connectivity=2, sparse_type="matrix")
-    assert isinstance(g, sp.sparse.csr_matrix)
-
-    g, n = pixel_graph(mask, connectivity=2, sparse_type="array")
     assert isinstance(g, sp.sparse.csr_array)
 
-    with pytest.raises(ValueError, match="`sparse_type` must be 'array' or 'matrix'"):
-        pixel_graph(mask, connectivity=2, sparse_type="unknown")
 
-
-@pytest.mark.parametrize("sparse_type", ["matrix", "array"])
-def test_central_pixel(sparse_type):
-    g, n = pixel_graph(mask, connectivity=2, sparse_type=sparse_type)
+def test_central_pixel():
+    g, n = pixel_graph(mask, connectivity=2)
     px, ds = central_pixel(g, n, shape=mask.shape)
     np.testing.assert_array_equal(px, (1, 1))
     s2 = np.sqrt(2)
@@ -47,8 +36,7 @@ def test_central_pixel(sparse_type):
     assert px == 1
 
 
-@pytest.mark.parametrize("sparse_type", ["matrix", "array"])
-def test_edge_function(sparse_type):
+def test_edge_function():
     def edge_func(values_src, values_dst, distances):
         return np.abs(values_src - values_dst) + distances
 
@@ -57,7 +45,6 @@ def test_edge_function(sparse_type):
         mask=mask,
         connectivity=2,
         edge_function=edge_func,
-        sparse_type=sparse_type,
     )
     s2 = np.sqrt(2)
     np.testing.assert_allclose(g[0, 1], np.abs(image[0, 0] - image[1, 1]) + s2)
@@ -65,17 +52,15 @@ def test_edge_function(sparse_type):
     np.testing.assert_array_equal(n, [0, 4, 5, 7])
 
 
-@pytest.mark.parametrize("sparse_type", ["matrix", "array"])
-def test_default_edge_func(sparse_type):
-    g, n = pixel_graph(image, spacing=np.array([0.78, 0.78]), sparse_type=sparse_type)
+def test_default_edge_func():
+    g, n = pixel_graph(image, spacing=np.array([0.78, 0.78]))
     num_edges = len(g.data) // 2  # each edge appears in both directions
     assert num_edges == 12  # lattice in a (3, 3) grid
     np.testing.assert_almost_equal(g[0, 1], 0.78 * np.abs(image[0, 0] - image[0, 1]))
     np.testing.assert_array_equal(n, np.arange(image.size))
 
 
-@pytest.mark.parametrize("sparse_type", ["matrix", "array"])
-def test_no_mask_with_edge_func(sparse_type):
+def test_no_mask_with_edge_func():
     """Ensure function `pixel_graph` runs when passing `edge_function` but not `mask`."""
     image = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
 
@@ -99,6 +84,6 @@ def test_no_mask_with_edge_func(sparse_type):
         * 0.5
     )
 
-    g, n = pixel_graph(image, edge_function=func, sparse_type=sparse_type)
+    g, n = pixel_graph(image, edge_function=func)
     np.testing.assert_array_equal(n, np.arange(image.size))
     np.testing.assert_array_equal(g.toarray(), expected_g)

--- a/tests/skimage2/metrics/test_segmentation_metrics.py
+++ b/tests/skimage2/metrics/test_segmentation_metrics.py
@@ -15,8 +15,7 @@ from _skimage2._shared.testing import (
 )
 
 
-@pytest.mark.parametrize("sparse_type", ["matrix", "array"])
-def test_contingency_table(sparse_type):
+def test_contingency_table():
     im_true = np.array([1, 2, 3, 4])
     im_test = np.array([1, 1, 8, 8])
 
@@ -30,28 +29,17 @@ def test_contingency_table(sparse_type):
         ]
     )
 
-    sparse_table2 = contingency_table(
-        im_true, im_test, normalize=True, sparse_type=sparse_type
-    )
+    sparse_table2 = contingency_table(im_true, im_test, normalize=True)
     table2 = sparse_table2.toarray()
     assert_array_equal(table1, table2)
 
 
-def test_contingency_table_sparse_type():
+def test_contingency_table_return_type():
     im_true = np.array([1, 2, 3, 4])
     im_test = np.array([1, 1, 8, 8])
 
     result = contingency_table(im_true, im_test)
-    assert isinstance(result, sp.sparse.csr_matrix)
-
-    result = contingency_table(im_true, im_test, sparse_type="matrix")
-    assert isinstance(result, sp.sparse.csr_matrix)
-
-    result = contingency_table(im_true, im_test, sparse_type="array")
     assert isinstance(result, sp.sparse.csr_array)
-
-    with pytest.raises(ValueError, match="`sparse_type` must be 'array' or 'matrix'"):
-        contingency_table(im_true, im_test, sparse_type="unknown")
 
 
 def test_vi():

--- a/tests/skimage2/morphology/test_misc.py
+++ b/tests/skimage2/morphology/test_misc.py
@@ -433,16 +433,18 @@ class Test_remove_near_objects:
             np.array(np.nonzero(spaced_objects), dtype=np.float64).transpose(),
         )
 
-        # Find all pairs of objects that are `distance` apart or closer.
-        # Not sparse_distance_matrix: it builds a coo_matrix internally, which
-        # SciPy 2.0 deprecates (https://github.com/scipy/scipy/issues/25943).
-        pairs = kdtree.query_pairs(r=distance, p=p_norm)
+        # Compute distance between all objects that are equal or smaller `distance`
+        distances = kdtree.sparse_distance_matrix(
+            kdtree, max_distance=distance, p=p_norm, output_type='dok_array'
+        )
         # There should be no objects left
-        assert len(pairs) == 0
+        assert distances.count_nonzero() == 0
 
         # But increasing by 1 should reveal a few objects
-        pairs = kdtree.query_pairs(r=distance + 1, p=p_norm)
-        assert len(pairs) > 0
+        distances = kdtree.sparse_distance_matrix(
+            kdtree, max_distance=distance + 1, p=p_norm, output_type='dok_array'
+        )
+        assert distances.count_nonzero() > 0
 
     @pytest.mark.parametrize("value", [0, 1])
     @pytest.mark.parametrize("dtype", supported_dtypes)

--- a/tests/skimage2/morphology/test_misc.py
+++ b/tests/skimage2/morphology/test_misc.py
@@ -435,7 +435,7 @@ class Test_remove_near_objects:
             np.array(np.nonzero(spaced_objects), dtype=np.float64).transpose(),
         )
         output_type = (
-            "doc_array" if Version(sp.__version__) >= Version("1.18") else None
+            "dok_array" if Version(sp.__version__) >= Version("1.18") else None
         )
 
         # Compute distance between all objects that are equal or smaller `distance`

--- a/tests/skimage2/morphology/test_misc.py
+++ b/tests/skimage2/morphology/test_misc.py
@@ -433,18 +433,16 @@ class Test_remove_near_objects:
             np.array(np.nonzero(spaced_objects), dtype=np.float64).transpose(),
         )
 
-        # Compute distance between all objects that are equal or smaller `distance`
-        distances = kdtree.sparse_distance_matrix(
-            kdtree, max_distance=distance, p=p_norm
-        )
+        # Find all pairs of objects that are `distance` apart or closer.
+        # Not sparse_distance_matrix: it builds a coo_matrix internally, which
+        # SciPy 2.0 deprecates (https://github.com/scipy/scipy/issues/25943).
+        pairs = kdtree.query_pairs(r=distance, p=p_norm)
         # There should be no objects left
-        assert distances.count_nonzero() == 0
+        assert len(pairs) == 0
 
         # But increasing by 1 should reveal a few objects
-        distances = kdtree.sparse_distance_matrix(
-            kdtree, max_distance=distance + 1, p=p_norm
-        )
-        assert distances.count_nonzero() > 0
+        pairs = kdtree.query_pairs(r=distance + 1, p=p_norm)
+        assert len(pairs) > 0
 
     @pytest.mark.parametrize("value", [0, 1])
     @pytest.mark.parametrize("dtype", supported_dtypes)

--- a/tests/skimage2/morphology/test_misc.py
+++ b/tests/skimage2/morphology/test_misc.py
@@ -434,8 +434,14 @@ class Test_remove_near_objects:
         kdtree = sp.spatial.cKDTree(
             np.array(np.nonzero(spaced_objects), dtype=np.float64).transpose(),
         )
+
+        # The default output_type for sparse_distance_matrix is 'dok_matrix' for
+        # all versions of SciPy that we support, but 'dok_matrix' is being replaced
+        # by 'dok_array'.  'dok_array' was added in Scipy 1.18.
+        # If we do not explicitly set 'dok_array' in SciPy 2.0,
+        # a warning is raised (pending https://github.com/scipy/scipy/issues/25943).
         output_type = (
-            "dok_array" if Version(sp.__version__) >= Version("1.18") else None
+            "dok_array" if Version(sp.__version__) >= Version("1.18") else "dok_matrix"
         )
 
         # Compute distance between all objects that are equal or smaller `distance`

--- a/tests/skimage2/morphology/test_misc.py
+++ b/tests/skimage2/morphology/test_misc.py
@@ -434,7 +434,9 @@ class Test_remove_near_objects:
         kdtree = sp.spatial.cKDTree(
             np.array(np.nonzero(spaced_objects), dtype=np.float64).transpose(),
         )
-        output_type = "doc_array" if Version(sp.__version__) < Version("1.18") else None
+        output_type = (
+            "doc_array" if Version(sp.__version__) >= Version("1.18") else None
+        )
 
         # Compute distance between all objects that are equal or smaller `distance`
         distances = kdtree.sparse_distance_matrix(

--- a/tests/skimage2/morphology/test_misc.py
+++ b/tests/skimage2/morphology/test_misc.py
@@ -2,6 +2,8 @@ import numpy as np
 import pytest
 import scipy as sp
 
+from packaging.version import Version
+
 from _skimage2.morphology import (
     remove_small_objects,
     remove_small_holes,
@@ -432,17 +434,18 @@ class Test_remove_near_objects:
         kdtree = sp.spatial.cKDTree(
             np.array(np.nonzero(spaced_objects), dtype=np.float64).transpose(),
         )
+        output_type = "doc_array" if Version(sp.__version__) < Version("1.18") else None
 
         # Compute distance between all objects that are equal or smaller `distance`
         distances = kdtree.sparse_distance_matrix(
-            kdtree, max_distance=distance, p=p_norm, output_type='dok_array'
+            kdtree, max_distance=distance, p=p_norm, output_type=output_type
         )
         # There should be no objects left
         assert distances.count_nonzero() == 0
 
         # But increasing by 1 should reveal a few objects
         distances = kdtree.sparse_distance_matrix(
-            kdtree, max_distance=distance + 1, p=p_norm, output_type='dok_array'
+            kdtree, max_distance=distance + 1, p=p_norm, output_type=output_type
         )
         assert distances.count_nonzero() > 0
 


### PR DESCRIPTION
Fixes #8223.

SciPy 2.0 deprecates the sparse matrix classes in favor of sparse arrays and will remove them no earlier than SciPy 2.2, according to scipy/scipy#24888. The warning is absent in SciPy 1.18, the current release, but present in the `scipy 2.0.0.dev0` nightly, where our error-on-warning pytest configuration turns it into 38 test failures.

## :warning: Public API change in `skimage2`

`sparse_type` is **removed** from `skimage2.graph.pixel_graph` and `skimage2.metrics.contingency_table`, which now always return a `scipy.sparse.csr_array`. This is a deliberate clean break, and the part of the PR that needs a decision rather than a review. The two types disagree about the `*` operator: matrix multiplication for `csr_matrix`, elementwise multiplication for `csr_array`.

`skimage` v1 is unaffected. It keeps `sparse_type` and its `"matrix"` default, and announces the `skimage2` difference through `ski2_migration_decorator`.

## SciPy-internal warning

`cKDTree.sparse_distance_matrix` builds a `coo_matrix` internally and warns even though the caller never asks for one, which broke a `remove_objects_by_distance` test that handles no sparse data itself. `output_type="dok_array"` avoids the warning but only exists in SciPy 1.18, and we support 1.15 and newer, so the test now uses `query_pairs`, which returns a plain set. I reported the bug upstream in scipy/scipy#25943.

## Testing

`pytest tests/` on SciPy 1.18 gives 19206 passed, 2 skipped. Against a real `scipy 2.0.0.dev0` build, the array paths emit no warning and the matrix paths reproduce the reported failure. `query_pairs` is warning-free on SciPy 1.15.3, 1.16.3, 1.17.1 and 2.0.0.dev0.

## AI disclosure

Produced with Claude (Opus 5) assisting, per the AI policy. The commits carry `Assisted-by:` tags.

### Release note

```release-note
`skimage2.graph.pixel_graph` and `skimage2.metrics.contingency_table` always return a `scipy.sparse.csr_array` and no longer accept a `sparse_type` parameter. The corresponding `skimage` functions are unchanged and still return a `scipy.sparse.csr_matrix` by default.
```
