### PR TITLE
Fix int overflow in find_boundaries(mode='outer')

### DIFF
--- a/src/_skimage2/segmentation/boundaries.py
+++ b/src/_skimage2/segmentation/boundaries.py
@@ -171,24 +171,25 @@ def find_boundaries(label_img, connectivity=1, mode='thick', background=0):
             boundaries &= foreground_image
         elif mode == 'outer':
             background_image = label_img == background
+            foreground_image = ~background_image
             inverted_background = np.array(label_img, copy=True)
-            if np.any(background_image):
+            if np.any(background_image) and np.any(foreground_image):
                 dtype_max = np.iinfo(label_img.dtype).max
-                data_max = int(label_img.max())
-                if data_max >= dtype_max:
+                label_max = int(label_img[foreground_image].max())
+                if label_max >= dtype_max:
                     raise ValueError(
                         "find_boundaries with mode='outer' needs a value "
                         "larger than the largest label to mark background "
-                        f"internally, but label_img already reaches the "
-                        f"{label_img.dtype} maximum ({dtype_max}). Cast "
+                        f"internally, but the largest label already reaches "
+                        f"the {label_img.dtype} maximum ({dtype_max}). Cast "
                         "label_img to a wider integer dtype."
                     )
-                inverted_background[background_image] = data_max + 1
+                inverted_background[background_image] = label_max + 1
             footprint = ndi.generate_binary_structure(ndim, ndim)
             adjacent_objects = (
                 dilation(label_img, footprint, mode='reflect')
                 != erosion(inverted_background, footprint, mode='reflect')
-            ) & ~background_image
+            ) & foreground_image
             boundaries &= background_image | adjacent_objects
         return boundaries
     else:

--- a/src/_skimage2/segmentation/boundaries.py
+++ b/src/_skimage2/segmentation/boundaries.py
@@ -170,11 +170,21 @@ def find_boundaries(label_img, connectivity=1, mode='thick', background=0):
             foreground_image = label_img != background
             boundaries &= foreground_image
         elif mode == 'outer':
-            max_label = np.iinfo(label_img.dtype).max
             background_image = label_img == background
-            footprint = ndi.generate_binary_structure(ndim, ndim)
             inverted_background = np.array(label_img, copy=True)
-            inverted_background[background_image] = max_label
+            if np.any(background_image):
+                dtype_max = np.iinfo(label_img.dtype).max
+                data_max = int(label_img.max())
+                if data_max >= dtype_max:
+                    raise ValueError(
+                        "find_boundaries with mode='outer' needs a value "
+                        "larger than the largest label to mark background "
+                        f"internally, but label_img already reaches the "
+                        f"{label_img.dtype} maximum ({dtype_max}). Cast "
+                        "label_img to a wider integer dtype."
+                    )
+                inverted_background[background_image] = data_max + 1
+            footprint = ndi.generate_binary_structure(ndim, ndim)
             adjacent_objects = (
                 dilation(label_img, footprint, mode='reflect')
                 != erosion(inverted_background, footprint, mode='reflect')

--- a/tests/skimage/segmentation/test_boundaries.py
+++ b/tests/skimage/segmentation/test_boundaries.py
@@ -235,3 +235,26 @@ def test_find_boundaries_outer_no_headroom_raises(dtype):
     image[1, 1] = np.iinfo(dtype).max
     with pytest.raises(ValueError):
         find_boundaries(image, mode='outer')
+
+
+@pytest.mark.parametrize('dtype', [np.int8, np.uint8])
+def test_find_boundaries_outer_background_at_dtype_max(dtype):
+    # Only the labels themselves need headroom; a `background` value at the
+    # dtype maximum is replaced before erosion and must not exhaust it.
+    dtype_max = np.iinfo(dtype).max
+    image = np.full((5, 5), dtype_max, dtype=dtype)
+    image[1:4, 1:4] = 1
+    image[2, 2] = 2
+
+    ref = np.array(
+        [
+            [False, True, True, True, False],
+            [True, True, True, True, True],
+            [True, True, True, True, True],
+            [True, True, True, True, True],
+            [False, True, True, True, False],
+        ],
+        dtype=bool,
+    )
+    result = find_boundaries(image, mode='outer', background=dtype_max)
+    assert_array_equal(result, ref)

--- a/tests/skimage/segmentation/test_boundaries.py
+++ b/tests/skimage/segmentation/test_boundaries.py
@@ -158,3 +158,80 @@ def test_boundaries_constant_image(mode):
     ones = np.ones((8, 8), dtype=int)
     b = find_boundaries(ones, mode=mode)
     assert np.all(b == 0)
+
+
+def test_find_boundaries_outer_overflow():
+    # Regression test for https://github.com/scikit-image/scikit-image/issues/4558
+    # mode='outer' used to mark background pixels with the dtype's true
+    # maximum value before eroding, which silently overflowed for wide
+    # integer dtypes (e.g. int64) and produced wrong boundaries.
+    source = np.array(
+        [
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 1, 1, 1, 1, 1, 1, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+        ],
+        dtype=np.int64,
+    )
+    ref = np.array(
+        [
+            [0, 1, 1, 1, 1, 1, 1, 0],
+            [1, 0, 0, 0, 0, 0, 0, 1],
+            [0, 1, 1, 1, 1, 1, 1, 0],
+        ]
+    )
+    result = find_boundaries(source, connectivity=1, mode='outer', background=0)
+    assert_array_equal(result.astype(int), ref)
+
+
+def test_find_boundaries_outer_all_background():
+    image = np.zeros((5, 5), dtype=np.int64)
+    result = find_boundaries(image, mode='outer')
+    assert np.all(result == 0)
+
+
+def test_find_boundaries_outer_bool():
+    image = np.zeros((5, 5), dtype=bool)
+    image[2:5, 2:5] = True
+
+    ref = np.array(
+        [
+            [False, False, False, False, False],
+            [False, False, True, True, True],
+            [False, True, False, False, False],
+            [False, True, False, False, False],
+            [False, True, False, False, False],
+        ],
+        dtype=bool,
+    )
+    result = find_boundaries(image, mode='outer')
+    assert_array_equal(result, ref)
+
+
+@pytest.mark.parametrize('dtype', [np.int8, np.uint8])
+def test_find_boundaries_outer_narrow_dtype(dtype):
+    image = np.zeros((5, 5), dtype=dtype)
+    image[2:5, 2:5] = 1
+
+    ref = np.array(
+        [
+            [False, False, False, False, False],
+            [False, False, True, True, True],
+            [False, True, False, False, False],
+            [False, True, False, False, False],
+            [False, True, False, False, False],
+        ],
+        dtype=bool,
+    )
+    result = find_boundaries(image, mode='outer')
+    assert_array_equal(result, ref)
+
+
+@pytest.mark.parametrize('dtype', [np.int8, np.uint8])
+def test_find_boundaries_outer_no_headroom_raises(dtype):
+    # Regression test for https://github.com/scikit-image/scikit-image/issues/4558
+    # No integer headroom is left to mark background internally.
+    image = np.zeros((3, 3), dtype=dtype)
+    image[1, 1] = np.iinfo(dtype).max
+    with pytest.raises(ValueError):
+        find_boundaries(image, mode='outer')

--- a/tests/skimage2/segmentation/test_boundaries.py
+++ b/tests/skimage2/segmentation/test_boundaries.py
@@ -235,3 +235,26 @@ def test_find_boundaries_outer_no_headroom_raises(dtype):
     image[1, 1] = np.iinfo(dtype).max
     with pytest.raises(ValueError):
         find_boundaries(image, mode='outer')
+
+
+@pytest.mark.parametrize('dtype', [np.int8, np.uint8])
+def test_find_boundaries_outer_background_at_dtype_max(dtype):
+    # Only the labels themselves need headroom; a `background` value at the
+    # dtype maximum is replaced before erosion and must not exhaust it.
+    dtype_max = np.iinfo(dtype).max
+    image = np.full((5, 5), dtype_max, dtype=dtype)
+    image[1:4, 1:4] = 1
+    image[2, 2] = 2
+
+    ref = np.array(
+        [
+            [False, True, True, True, False],
+            [True, True, True, True, True],
+            [True, True, True, True, True],
+            [True, True, True, True, True],
+            [False, True, True, True, False],
+        ],
+        dtype=bool,
+    )
+    result = find_boundaries(image, mode='outer', background=dtype_max)
+    assert_array_equal(result, ref)

--- a/tests/skimage2/segmentation/test_boundaries.py
+++ b/tests/skimage2/segmentation/test_boundaries.py
@@ -158,3 +158,80 @@ def test_boundaries_constant_image(mode):
     ones = np.ones((8, 8), dtype=int)
     b = find_boundaries(ones, mode=mode)
     assert np.all(b == 0)
+
+
+def test_find_boundaries_outer_overflow():
+    # Regression test for https://github.com/scikit-image/scikit-image/issues/4558
+    # mode='outer' used to mark background pixels with the dtype's true
+    # maximum value before eroding, which silently overflowed for wide
+    # integer dtypes (e.g. int64) and produced wrong boundaries.
+    source = np.array(
+        [
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 1, 1, 1, 1, 1, 1, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+        ],
+        dtype=np.int64,
+    )
+    ref = np.array(
+        [
+            [0, 1, 1, 1, 1, 1, 1, 0],
+            [1, 0, 0, 0, 0, 0, 0, 1],
+            [0, 1, 1, 1, 1, 1, 1, 0],
+        ]
+    )
+    result = find_boundaries(source, connectivity=1, mode='outer', background=0)
+    assert_array_equal(result.astype(int), ref)
+
+
+def test_find_boundaries_outer_all_background():
+    image = np.zeros((5, 5), dtype=np.int64)
+    result = find_boundaries(image, mode='outer')
+    assert np.all(result == 0)
+
+
+def test_find_boundaries_outer_bool():
+    image = np.zeros((5, 5), dtype=bool)
+    image[2:5, 2:5] = True
+
+    ref = np.array(
+        [
+            [False, False, False, False, False],
+            [False, False, True, True, True],
+            [False, True, False, False, False],
+            [False, True, False, False, False],
+            [False, True, False, False, False],
+        ],
+        dtype=bool,
+    )
+    result = find_boundaries(image, mode='outer')
+    assert_array_equal(result, ref)
+
+
+@pytest.mark.parametrize('dtype', [np.int8, np.uint8])
+def test_find_boundaries_outer_narrow_dtype(dtype):
+    image = np.zeros((5, 5), dtype=dtype)
+    image[2:5, 2:5] = 1
+
+    ref = np.array(
+        [
+            [False, False, False, False, False],
+            [False, False, True, True, True],
+            [False, True, False, False, False],
+            [False, True, False, False, False],
+            [False, True, False, False, False],
+        ],
+        dtype=bool,
+    )
+    result = find_boundaries(image, mode='outer')
+    assert_array_equal(result, ref)
+
+
+@pytest.mark.parametrize('dtype', [np.int8, np.uint8])
+def test_find_boundaries_outer_no_headroom_raises(dtype):
+    # Regression test for https://github.com/scikit-image/scikit-image/issues/4558
+    # No integer headroom is left to mark background internally.
+    image = np.zeros((3, 3), dtype=dtype)
+    image[1, 1] = np.iinfo(dtype).max
+    with pytest.raises(ValueError):
+        find_boundaries(image, mode='outer')


### PR DESCRIPTION
Fixes #4558.

`find_boundaries(..., mode='outer')` marked background pixels with the label dtype's true maximum value (`np.iinfo(dtype).max`) before eroding them. For wide integer dtypes (int64, uint64), that sentinel overflows inside `scipy.ndimage.grey_erosion`/`grey_dilation`, wrapping to the dtype's minimum at several positions and corrupting the comparison the function uses to detect object-adjacent background. This is the "different results on different platforms" behavior from the original report: it reproduces on Linux/macOS with the platform's default 64-bit int, and is masked on Windows only because `np.array([...])` there defaults to a narrower int type.

This replaces the sentinel with a value derived from the data instead of the dtype: `int(label_img.max()) + 1`, computed only when the image actually has background pixels. It only needs to exceed the labels actually present, so it never approaches the dtype's numeric ceiling, and it works the same way across every integer dtype without a per-dtype constant. If a label already sits at the dtype's true maximum and background is also present, there's no integer headroom left; that case now raises a clear `ValueError` instead of silently corrupting the output.

One incidental behavior change worth flagging: previously, calling `mode='outer'` with a float `label_img` always raised `ValueError: Invalid integer data type 'f'`, because the old sentinel computation ran unconditionally. It now only runs when background pixels are present, so a float array with no pixels equal to `background` no longer raises. Float input isn't documented for this function (the docstring specifies "array of int or bool"), and the old error was opaque rather than intentional, so this seems like a net improvement, but it is a real change in what currently runs without erroring.

Tests added (mirrored in `tests/skimage2/segmentation/test_boundaries.py` and `tests/skimage/segmentation/test_boundaries.py`): the original report's exact array, an all-background image, `bool` input, narrow integer dtypes (`int8`/`uint8`) both away from and at their ceiling (the new `ValueError` case).

```release-note
Fix a bug in `find_boundaries` (and `mark_boundaries`, which calls it) where
`mode='outer'` could silently produce wrong results for integer label images
with a wide dtype (`int64`/`uint64`), due to an internal sentinel value that
overflowed during erosion.
```

Assisted-by: Claude:claude-sonnet-5
