### PR TITLE
Support Python 3.15

### DIFF
--- a/.github/workflows/_test_linux_for_python_x.yaml
+++ b/.github/workflows/_test_linux_for_python_x.yaml
@@ -102,7 +102,7 @@ jobs:
         run: bash .github/scripts/check-run-all-tests-label.sh
 
       - name: Run tests
-        if: ${{ inputs.python-version != '3.14t' }}
+        if: ${{ !endsWith(inputs.python-version, 't') }}
         env:
           TEST_MODIFIED: ${{ steps.check-run-all-tests-label.outputs.test_modified }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
@@ -123,8 +123,8 @@ jobs:
         run: |
           python doc/tools/run_migration_doctests.py
 
-      - name: Run multithreaded tests (3.14t only)
-        if: ${{ inputs.python-version == '3.14t' }}
+      - name: Run multithreaded tests (free-threaded only)
+        if: ${{ endsWith(inputs.python-version, 't') }}
         env:
           # A lazy loader configuration parameter
           EAGER_IMPORT: ${{ inputs.EAGER_IMPORT }}

--- a/.github/workflows/test-linux.yaml
+++ b/.github/workflows/test-linux.yaml
@@ -33,6 +33,16 @@ jobs:
     with:
       python-version: 3.14t
 
+  build-linux-315:
+    uses: ./.github/workflows/_build_linux_for_python_x.yaml
+    with:
+      python-version: 3.15
+
+  build-linux-315t:
+    uses: ./.github/workflows/_build_linux_for_python_x.yaml
+    with:
+      python-version: 3.15t
+
   test-linux-312:
     name: test-linux-cp3.12-${{ matrix.OPTIONS_NAME }}
     needs: [build-linux-312]
@@ -96,6 +106,22 @@ jobs:
       python-version: 3.14t
       OPTIONS_NAME: "main"
 
+  test-linux-315:
+    name: test-linux-cp3.15-main
+    needs: [build-linux-315]
+    uses: ./.github/workflows/_test_linux_for_python_x.yaml
+    with:
+      python-version: 3.15
+      OPTIONS_NAME: "main"
+
+  test-linux-315t:
+    name: test-linux-cp3.15t-main
+    needs: [build-linux-315t]
+    uses: ./.github/workflows/_test_linux_for_python_x.yaml
+    with:
+      python-version: 3.15t
+      OPTIONS_NAME: "main"
+
   report-failures:
     runs-on: ubuntu-latest
     needs:
@@ -104,10 +130,14 @@ jobs:
         build-linux-313,
         build-linux-314,
         build-linux-314t,
+        build-linux-315,
+        build-linux-315t,
         test-linux-312,
         test-linux-313,
         test-linux-314,
         test-linux-314t,
+        test-linux-315,
+        test-linux-315t,
       ]
     if: ${{ always() && github.ref == 'refs/heads/main' && contains(needs.*.result, 'failure') }}
     permissions:

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -30,6 +30,11 @@ jobs:
             os: macos-15-intel
             OPTIONAL_DEPS: 1
             OPTIONS_NAME: "default"
+          - python-version: "3.15"
+            os: macos-latest
+            # Optional deps have no cp315 wheels yet
+            OPTIONAL_DEPS: 0
+            OPTIONS_NAME: "default"
     env:
       CC: ccache /usr/bin/clang
       CXX: ccache /usr/bin/clang++

--- a/.github/workflows/test-pyodide.yaml
+++ b/.github/workflows/test-pyodide.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
+      - uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
           CIBW_PLATFORM: pyodide
           CIBW_BUILD: cp313-pyodide_wasm32

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -41,6 +41,10 @@ jobs:
             MINIMUM_REQUIREMENTS: 0
             OPTIONAL_DEPS: 0
             OPTIONS_NAME: "default"
+          - python-version: "3.15"
+            MINIMUM_REQUIREMENTS: 0
+            OPTIONAL_DEPS: 0
+            OPTIONS_NAME: "default"
 
     steps:
       - name: Checkout scikit-image

--- a/.github/workflows/wheels-recipe.yaml
+++ b/.github/workflows/wheels-recipe.yaml
@@ -22,14 +22,14 @@ jobs:
             macos-15-intel,
             macos-latest, # ARM-version of MacOS
           ]
-        build: ["cp312*", "cp313*", "cp314*"]
+        build: ["cp312*", "cp313*", "cp314*", "cp315*"]
 
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: pypa/cibuildwheel@9c00cb4f6b517705a3794b22395aedc36257242c # v3.2.1
+      - uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
           CIBW_BUILD: ${{ matrix.build }}
       - uses: actions/upload-artifact@v4
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, windows-11-arm]
-        build: ["cp312*", "cp313*", "cp314*"]
+        build: ["cp312*", "cp313*", "cp314*", "cp315*"]
 
     steps:
       - uses: actions/checkout@v5
@@ -55,7 +55,7 @@ jobs:
       - name: Set up LLVM toolchain for Windows ARM64
         if: matrix.os == 'windows-11-arm'
         uses: ./.github/windows_arm64_steps
-      - uses: pypa/cibuildwheel@9c00cb4f6b517705a3794b22395aedc36257242c # v3.2.1
+      - uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
           CIBW_BUILD: ${{ matrix.build }}
           CC: clang-cl
@@ -80,9 +80,11 @@ jobs:
             "cp312*manylinux*",
             "cp313*manylinux*",
             "cp314*manylinux*",
+            "cp315*manylinux*",
             "cp312*musllinux*",
             "cp313*musllinux*",
             "cp314*musllinux*",
+            "cp315*musllinux*",
           ]
 
     steps:
@@ -90,7 +92,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: pypa/cibuildwheel@9c00cb4f6b517705a3794b22395aedc36257242c # v3.2.1
+      - uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
           CIBW_BUILD: ${{ matrix.build }}
       - uses: actions/upload-artifact@v4
@@ -108,7 +110,7 @@ jobs:
           persist-credentials: false
 
       - name: Build and test scikit-image for Pyodide
-        uses: pypa/cibuildwheel@9c00cb4f6b517705a3794b22395aedc36257242c # v3.2.1
+        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
           CIBW_PLATFORM: pyodide
           # only build for newer pyodide_2025_0 ABI and not cp312-pyodide_wasm32 (pyodide_2024_0)

--- a/.github/workflows/wheels-recipe.yaml
+++ b/.github/workflows/wheels-recipe.yaml
@@ -55,9 +55,8 @@ jobs:
       - name: Set up LLVM toolchain for Windows ARM64
         if: matrix.os == 'windows-11-arm'
         uses: ./.github/windows_arm64_steps
-      # cibuildwheel v4+ bundles DLL dependencies into scikit_image.libs/ via delvewheel.
-      # This default is accepted. To opt out, add repair-wheel-command = "" under
-      # [tool.cibuildwheel.windows] in pyproject.toml.
+      # Wheel repair is disabled for Windows in pyproject.toml; see the comment
+      # on repair-wheel-command under [tool.cibuildwheel.windows].
       - uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
           CIBW_BUILD: ${{ matrix.build }}

--- a/.github/workflows/wheels-recipe.yaml
+++ b/.github/workflows/wheels-recipe.yaml
@@ -55,6 +55,9 @@ jobs:
       - name: Set up LLVM toolchain for Windows ARM64
         if: matrix.os == 'windows-11-arm'
         uses: ./.github/windows_arm64_steps
+      # cibuildwheel v4+ bundles DLL dependencies into scikit_image.libs/ via delvewheel.
+      # This default is accepted. To opt out, add repair-wheel-command = "" under
+      # [tool.cibuildwheel.windows] in pyproject.toml.
       - uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
           CIBW_BUILD: ${{ matrix.build }}
@@ -113,7 +116,7 @@ jobs:
         uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
           CIBW_PLATFORM: pyodide
-          # only build for newer pyodide_2025_0 ABI and not cp312-pyodide_wasm32 (pyodide_2024_0)
+          # cp313 only: skip cp314+ (pyodide 3.15 is 315.0.0a2 prerelease, not production)
           CIBW_BUILD: "cp313-pyodide_wasm32"
       - uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
     'Programming Language :: Python :: 3.14',
+    'Programming Language :: Python :: 3.15',
     'Programming Language :: Python :: 3 :: Only',
     'Topic :: Software Development :: Libraries',
     'Topic :: Scientific/Engineering',
@@ -299,6 +300,13 @@ test-extras = ["test", "optional_free_threaded"]
 select = "*-musllinux*"
 test-extras = ["test", "optional_free_threaded"]
 # SimpleITK does not support musllinux yet
+
+[[tool.cibuildwheel.overrides]]
+select = "cp315*"
+# scikit-learn, matplotlib, PyWavelets, and astropy have no cp315 wheels yet,
+# so the `optional` and `optional_free_threaded` extras cannot be installed.
+# Drop this override once they publish for 3.15.
+test-extras = ["test"]
 
 [tool.cibuildwheel.linux]
 environment = {PIP_PREFER_BINARY=1, SKIMAGE_LINK_FLAGS="-Wl,--strip-debug"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -313,6 +313,11 @@ environment = {PIP_PREFER_BINARY=1, SKIMAGE_LINK_FLAGS="-Wl,--strip-debug"}
 
 [tool.cibuildwheel.windows]
 archs = ["auto"]
+# cibuildwheel 4.0 made delvewheel the default repair command on Windows. Five
+# of our extension modules import msvcp140.dll, so the default would start
+# bundling it; disabling repair keeps wheel contents as they have always been.
+# Revisit as its own change, not as a side effect of a cibuildwheel bump.
+repair-wheel-command = ""
 
 [tool.cibuildwheel.macos]
 test-command = "pytest"


### PR DESCRIPTION
<!--
Please see the Contribution Guide:
https://scikit-image.org/docs/dev/development/contribute.html
For newcomers: this document has a checklist of what we expect in a PR.

Also please note our AI policy:
https://scikit-image.org/docs/dev/development/contribute.html#ai-policy
-->

Closes #8101.

Python 3.15 is at rc1 with a frozen ABI, and the build stack already publishes cp315 wheels. No library source needed changing, so this is packaging and CI only.

### Changes

- Declared Python 3.15 and added it to the Linux, macOS, and Windows test matrices, free-threaded 3.15t included.
- Built cp315 and cp315t wheels on every platform, which required upgrading cibuildwheel to v4.2.0.
- Dropped the `optional` extras from cp315 wheel tests, since scikit-learn, matplotlib, PyWavelets, and astropy have no cp315 wheels yet. Remove once they do.
- Kept Windows wheel repair off, which cibuildwheel 4.0 otherwise enables. It would start bundling `msvcp140.dll`; worth deciding separately.

### Testing

- Full suite on 3.15.0rc1, macOS arm64: 18722 passed, 0 failed.
- Every runtime dependency has cp315 and cp315t wheels on all eight target platforms.
- `pre-commit`, zizmor included, passes.

### AI usage

Written with Claude Code (Opus 5). Every commit carries an `Assisted-by:` trailer.

### Release note (optional)

<!-- See https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes -->

```release-note
Add support for Python 3.15, including free-threaded 3.15t, and publish cp315 wheels.
```
