### PR TITLE
Fix ~30s test startup penalty due to accidental binary_blobs input

### DIFF
--- a/src/_skimage2/data/_synthetic.py
+++ b/src/_skimage2/data/_synthetic.py
@@ -93,7 +93,8 @@ def binary_blobs(
     if blob_size > min_length:
         warn_external(
             f"`blob_size={blob_size}` is larger than a dimension "
-            f"in `shape={shape}` which may lead to unexpected results! "
+            f"in `shape={shape}` which may lead to unexpected results! ",
+            category=RuntimeWarning,
         )
 
     rng = np.random.default_rng(rng)

--- a/src/_skimage2/data/_synthetic.py
+++ b/src/_skimage2/data/_synthetic.py
@@ -21,10 +21,13 @@ def binary_blobs(
     shape : tuple of (int, ...)
         Shape of the output image.
     blob_size : float
-        Typical linear size of blob in pixels.
-        Values smaller than 1 may lead to unexpected results.
+        Typical linear size of blobs in pixels. Values smaller than 1 or larger
+        than `shape` may lead to unexpected results. The actual size is also
+        affected by `volume_fraction`.
     volume_fraction : float, in interval [0, 1], optional
-        Fraction of image pixels covered by the blobs.
+        Fraction of image pixels covered by the blobs. Blobs shrink
+        with smaller fractions, and grow and merge together with larger
+        fractions.
     rng : int or :class:`numpy.random.Generator`, optional
         Pseudo-random number generator.
         By default, a PCG64 generator is used (see :func:`numpy.random.default_rng`).
@@ -86,6 +89,11 @@ def binary_blobs(
         warn_external(
             "Clamping to `blob_size=0.1` to avoid allocating excessive memory.",
             category=RuntimeWarning,
+        )
+    if blob_size > min_length:
+        warn_external(
+            f"`blob_size={blob_size}` is larger than a dimension "
+            f"in `shape={shape}` which may lead to unexpected results! "
         )
 
     rng = np.random.default_rng(rng)

--- a/src/_skimage2/data/_synthetic.py
+++ b/src/_skimage2/data/_synthetic.py
@@ -21,9 +21,9 @@ def binary_blobs(
     shape : tuple of (int, ...)
         Shape of the output image.
     blob_size : float
-        Typical linear size of blobs in pixels. Values smaller than 1 or larger
-        than `shape` may lead to unexpected results. The actual size is also
-        affected by `volume_fraction`.
+        Typical linear size (diameter) of blobs in pixels. Values smaller than
+        1 or larger than any length in `shape` may lead to unexpected results.
+        The actual size is also affected by `volume_fraction`.
     volume_fraction : float, in interval [0, 1], optional
         Fraction of image pixels covered by the blobs. Blobs shrink
         with smaller fractions, and grow and merge together with larger

--- a/tests/skimage2/data/test_synthetic.py
+++ b/tests/skimage2/data/test_synthetic.py
@@ -69,6 +69,27 @@ class Test_binary_blobs:
         else:
             np.testing.assert_equal(result, 1)
 
+    @pytest.mark.parametrize("blob_size", [81, 300])
+    @pytest.mark.parametrize("volume_fraction", [0.9, 0.1])
+    def test_large_blob_size(self, blob_size, volume_fraction):
+        shape = (80, 100)
+        # No warning, blob size warns when longer than shape
+        result = binary_blobs(
+            shape, blob_size=min(shape), volume_fraction=volume_fraction, rng=SEED
+        )
+        assert result.shape == shape
+
+        regex = r"`blob_size=.* is larger than a dimension"
+        with pytest.warns(RuntimeWarning, match=regex) as record:
+            result = binary_blobs(
+                shape, blob_size=blob_size, volume_fraction=volume_fraction, rng=SEED
+            )
+        assert_stacklevel(record, offset=-3)
+
+        # Volume fraction is still forced correctly
+        actual_fraction = result.sum() / result.size
+        np.testing.assert_allclose(actual_fraction, volume_fraction, rtol=0.01)
+
     @pytest.mark.filterwarnings("ignore:Requested `blob_size` .* is smaller than 1")
     def test_blob_size_clamping(self):
         # A very small `blob_size` will allocate excessive memory.

--- a/tests/skimage2/restoration/test_j_invariant.py
+++ b/tests/skimage2/restoration/test_j_invariant.py
@@ -25,7 +25,7 @@ xfail_without_pywt = pytest.mark.xfail(
 test_img = img_as_float(camera())
 test_img_color = img_as_float(chelsea())
 # Reproduce skimage behavior.
-_blobs = binary_blobs((64, 64, 64), blob_size=512 * 64)
+_blobs = binary_blobs((64, 64, 64), blob_size=0.1 * 64)
 test_img_3d = img_as_float(_blobs) / 2
 noisy_img = random_noise(test_img, mode='gaussian', var=0.01)
 noisy_img_color = random_noise(test_img_color, mode='gaussian', var=0.01)


### PR DESCRIPTION
This call to `binary_blobs` was migrated from the skimage1 version of the tests. I think the excessively large `blob_size=512 * 64` was accidentally chosen.

This input causes an internal call to `gaussian` with an equally large `sigma=8192`. Filtering an (64, 64, 64) shaped array with such a large filter is very slow (30s on my system).

Because this call was in the module namespace of a test module, this slowdown had to be paid each time the module was hit during test collection. Effectively slowing down all invocations of

```
spin test -- -k <match_test>
```

that didn't avoid test_j_invariant.py via additional filtering by
directory.

If people want to iterate on the added warning and docstring tweaks, I'd rather do that in another PR to get this quality of live fix fast. :sweat_smile: 

### Release note (optional)

<!-- See https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes -->

```release-note
Fix test suite startup penalty due to accidental binary_blobs input.
{label="Infrastructure"}
```

```release-note
Improve docstring of `skimage2.data.binary_blobs`.
{label="Documentation"}
```