### PR TITLE
Reject P > 31 in local_binary_pattern for the power-of-two methods

### DIFF
--- a/src/_skimage2/feature/texture.py
+++ b/src/_skimage2/feature/texture.py
@@ -327,7 +327,11 @@ def local_binary_pattern(image, P, R, method='default'):
         2D grayscale image.
     P : int
         Number of circularly symmetric neighbor set points (quantization of
-        the angular space).
+        the angular space). For the ``'default'`` and ``'ror'`` methods, ``P``
+        must not exceed 31: those codes are accumulated in a 32-bit signed
+        integer, which cannot represent a pattern wider than that. The
+        ``'uniform'``, ``'nri_uniform'`` and ``'var'`` methods do not weight
+        neighbors by powers of two and take any ``P``.
     R : float
         Radius of circle (spatial resolution of the operator).
     method : {'default', 'ror', 'uniform', 'nri_uniform', 'var'}, optional
@@ -354,6 +358,11 @@ def local_binary_pattern(image, P, R, method='default'):
     -------
     output : (M, N) array
         LBP image.
+
+    Raises
+    ------
+    ValueError
+        If ``P > 31`` and ``method`` is ``'default'`` or ``'ror'``.
 
     References
     ----------
@@ -382,6 +391,18 @@ def local_binary_pattern(image, P, R, method='default'):
         'nri_uniform': ord('N'),
         'var': ord('V'),
     }
+    # The 'default' and 'ror' codes are a sum of one power of two per neighbor,
+    # accumulated in the int32 weights of the Cython kernel. At P == 32 the last
+    # weight, 2 ** 31, overflows int32, so the returned codes go negative
+    # instead of enumerating the 2 ** P patterns, with no error or warning. The
+    # other methods do not weight neighbors by powers of two and are unaffected.
+    if method.lower() in ('default', 'ror') and P > 31:
+        raise ValueError(
+            f"P must not exceed 31 for method={method!r}, got P={P}. The "
+            "pattern code is accumulated in a 32-bit signed integer, which "
+            "cannot represent a wider pattern. Use method='uniform', "
+            "'nri_uniform' or 'var' for a larger neighborhood."
+        )
     if np.issubdtype(image.dtype, np.floating):
         warnings.warn(
             "Applying `local_binary_pattern` to floating-point images may "

--- a/src/_skimage2/feature/texture.py
+++ b/src/_skimage2/feature/texture.py
@@ -330,8 +330,10 @@ def local_binary_pattern(image, P, R, method='default'):
         the angular space). For the ``'default'`` and ``'ror'`` methods, ``P``
         must not exceed 31: those codes are accumulated in a 32-bit signed
         integer, which cannot represent a pattern wider than that. The
-        ``'uniform'``, ``'nri_uniform'`` and ``'var'`` methods do not weight
-        neighbors by powers of two and take any ``P``.
+        ``'uniform'`` and ``'var'`` methods do not weight neighbors by powers
+        of two and accept any ``P``. ``'nri_uniform'`` escapes that limit too,
+        but enumerates ``P * (P - 1) + 3`` codes in a 32-bit integer, so it
+        requires ``P <= 46341``.
     R : float
         Radius of circle (spatial resolution of the operator).
     method : {'default', 'ror', 'uniform', 'nri_uniform', 'var'}, optional

--- a/tests/skimage/feature/test_texture.py
+++ b/tests/skimage/feature/test_texture.py
@@ -347,6 +347,32 @@ class TestLBP:
         )
         np.testing.assert_array_almost_equal(lbp, ref)
 
+    @pytest.mark.parametrize('method', ['default', 'ror', 'DEFAULT', 'RoR'])
+    def test_p_above_int32_capacity_raises(self, method):
+        # gh-5025: the 'default' and 'ror' codes sum one power of two per
+        # neighbor into an int32, so at P == 32 the last weight (2 ** 31)
+        # overflows and the returned codes go negative -- silently, with no
+        # error or warning. Measured on 0.26.0: P=32 'default' returned codes
+        # from -2147483647, and 'ror' returned a maximum of 0.
+        with pytest.raises(ValueError, match='must not exceed 31'):
+            local_binary_pattern(self.image, 32, 1, method)
+
+    @pytest.mark.parametrize('method', ['uniform', 'nri_uniform', 'var'])
+    def test_p_above_31_allowed_for_unweighted_methods(self, method):
+        # These methods do not weight neighbors by powers of two, so the int32
+        # ceiling does not apply and a wide neighborhood stays valid.
+        lbp = local_binary_pattern(self.image, 32, 1, method)
+        assert lbp.shape == self.image.shape
+        assert np.all(lbp >= 0)
+
+    def test_p_at_int32_limit_is_accepted(self):
+        # P == 31 is the largest pattern an int32 can hold: the weights top out
+        # at 2 ** 30 and the widest code is 2 ** 31 - 1. It must not be
+        # rejected by the guard above.
+        lbp = local_binary_pattern(self.image, 31, 1, 'default')
+        assert np.all(lbp >= 0)
+        assert lbp.max() <= 2**31 - 1
+
 
 class TestMBLBP:
     def test_single_mblbp(self):

--- a/tests/skimage2/feature/test_texture.py
+++ b/tests/skimage2/feature/test_texture.py
@@ -347,6 +347,32 @@ class TestLBP:
         )
         np.testing.assert_array_almost_equal(lbp, ref)
 
+    @pytest.mark.parametrize('method', ['default', 'ror', 'DEFAULT', 'RoR'])
+    def test_p_above_int32_capacity_raises(self, method):
+        # gh-5025: the 'default' and 'ror' codes sum one power of two per
+        # neighbor into an int32, so at P == 32 the last weight (2 ** 31)
+        # overflows and the returned codes go negative -- silently, with no
+        # error or warning. Measured on 0.26.0: P=32 'default' returned codes
+        # from -2147483647, and 'ror' returned a maximum of 0.
+        with pytest.raises(ValueError, match='must not exceed 31'):
+            local_binary_pattern(self.image, 32, 1, method)
+
+    @pytest.mark.parametrize('method', ['uniform', 'nri_uniform', 'var'])
+    def test_p_above_31_allowed_for_unweighted_methods(self, method):
+        # These methods do not weight neighbors by powers of two, so the int32
+        # ceiling does not apply and a wide neighborhood stays valid.
+        lbp = local_binary_pattern(self.image, 32, 1, method)
+        assert lbp.shape == self.image.shape
+        assert np.all(lbp >= 0)
+
+    def test_p_at_int32_limit_is_accepted(self):
+        # P == 31 is the largest pattern an int32 can hold: the weights top out
+        # at 2 ** 30 and the widest code is 2 ** 31 - 1. It must not be
+        # rejected by the guard above.
+        lbp = local_binary_pattern(self.image, 31, 1, 'default')
+        assert np.all(lbp >= 0)
+        assert lbp.max() <= 2**31 - 1
+
 
 class TestMBLBP:
     def test_single_mblbp(self):


### PR DESCRIPTION
Closes #5025.

## Description

`local_binary_pattern` silently returns negative codes for `P > 31` with `method='default'` or `'ror'`. The codes are a sum of one power of two per neighbor, accumulated in the int32 weights of the Cython kernel:

```cython
cdef int[::1] weights = 2 ** np.arange(P, dtype=np.int32)
```

At `P == 32` the last weight, `2 ** 31`, overflows int32. Measured on 0.26.0:

| P | method | min | max |
| --- | --- | --- | --- |
| 31 | default | 0 | 2147483647 |
| 32 | default | **-2147483647** | 2147450880 |
| 32 | ror | **-2147483648** | 0 |

This raises `ValueError` instead, and documents the limit. `P == 31` stays valid — its widest code is `2 ** 31 - 1`, exactly int32's maximum. `'uniform'`, `'nri_uniform'` and `'var'` do not weight neighbors by powers of two and are left unrestricted (verified: all three still accept `P = 32`).

Two notes for the reviewers:

- #5025 gives the bound as 30. Measurement puts it at 31; `P = 31` produces correct codes.
- The issue also observes that the Cython buffer is typed `int` rather than a fixed-width type, so the 32-bit assumption is implicit. I left that alone to keep this change to the silent-overflow bug — happy to follow up separately if you'd like it typed explicitly.

## Tests

`TestLBP` gains three cases in both `tests/skimage/` and `tests/skimage2/`: the rejection (parametrized over `default`, `ror` and mixed case), that the unweighted methods still accept `P = 32`, and that `P = 31` is still accepted with a maximum inside int32.

Built from source and ran locally: 82 passed in both texture files; 829 passed across `tests/*/feature` excluding `test_corner.py`, which fails to collect with `'filterwarnings' not found` on a clean checkout too. Removing just the guard fails exactly the four rejection cells and nothing else. `ruff check` and `ruff format --check` clean.

---

Tooling disclosure, per the AI policy: written with Claude Code, and the commit carries `Assisted-by: Claude Code (Opus 5)`.

:robot: _The description above was drafted with AI assistance rather than by hand; the measurements in it were produced by running the code. Happy to rewrite it in my own words if you'd prefer that._ :robot:
