### PR TITLE
Validate bandwidth in gabor_kernel

### DIFF
--- a/src/_skimage2/filters/_gabor.py
+++ b/src/_skimage2/filters/_gabor.py
@@ -40,9 +40,10 @@ def gabor_kernel(
     theta : float, optional
         Orientation in radians. If 0, the harmonic is in the x-direction.
     bandwidth : float, optional
-        The bandwidth captured by the filter. For fixed bandwidth, ``sigma_x``
-        and ``sigma_y`` will decrease with increasing frequency. This value is
-        ignored if ``sigma_x`` and ``sigma_y`` are set by the user.
+        The bandwidth captured by the filter. Must be greater than 0. For fixed
+        bandwidth, ``sigma_x`` and ``sigma_y`` will decrease with increasing
+        frequency. This value is ignored if ``sigma_x`` and ``sigma_y`` are set
+        by the user.
     sigma_x, sigma_y : float, optional
         Standard deviation in x- and y-directions. These directions apply to
         the kernel *before* rotation. If `theta = pi/2`, then the kernel is
@@ -83,6 +84,8 @@ def gabor_kernel(
     >>> ax.imshow(gk.real)       # doctest: +SKIP
     >>> plt.show()               # doctest: +SKIP
     """
+    if (sigma_x is None or sigma_y is None) and bandwidth <= 0:
+        raise ValueError(f"`bandwidth` must be > 0, got {bandwidth}")
     if sigma_x is None:
         sigma_x = _sigma_prefactor(bandwidth) / frequency
     if sigma_y is None:
@@ -145,9 +148,10 @@ def gabor(
     theta : float, optional
         Orientation in radians. If 0, the harmonic is in the x-direction.
     bandwidth : float, optional
-        The bandwidth captured by the filter. For fixed bandwidth, `sigma_x`
-        and `sigma_y` will decrease with increasing frequency. This value is
-        ignored if `sigma_x` and `sigma_y` are set by the user.
+        The bandwidth captured by the filter. Must be greater than 0. For fixed
+        bandwidth, `sigma_x` and `sigma_y` will decrease with increasing
+        frequency. This value is ignored if `sigma_x` and `sigma_y` are set by
+        the user.
     sigma_x, sigma_y : float, optional
         Standard deviation in x- and y-directions. These directions apply to
         the kernel *before* rotation. If ``theta = pi/2``, then the kernel is

--- a/tests/skimage/filters/test_gabor.py
+++ b/tests/skimage/filters/test_gabor.py
@@ -31,6 +31,38 @@ def test_gabor_kernel_bandwidth():
     assert_equal(kernel.shape, (9, 9))
 
 
+@pytest.mark.parametrize('bandwidth', [0, -0.5, -1])
+def test_gabor_kernel_invalid_bandwidth(bandwidth):
+    # `bandwidth=0` makes `_sigma_prefactor`'s denominator exactly zero, and a
+    # negative `bandwidth` makes it return a negative sigma, which is not a
+    # meaningful standard deviation. Both are rejected up front now.
+    with pytest.raises(ValueError, match='bandwidth'):
+        gabor_kernel(0.1, bandwidth=bandwidth)
+    with pytest.raises(ValueError, match='bandwidth'):
+        gabor(np.zeros((10, 10)), frequency=0.1, bandwidth=bandwidth)
+
+
+@pytest.mark.parametrize('sigma_kwargs', [{'sigma_x': 5.0}, {'sigma_y': 5.0}])
+def test_gabor_kernel_invalid_bandwidth_with_one_sigma(sigma_kwargs):
+    # Only one sigma is user-supplied, so the other is still derived from
+    # `bandwidth` and the guard must fire. Previously `bandwidth=-1` here left
+    # exactly one sigma negative, which flipped the sign of the whole kernel
+    # rather than cancelling out.
+    with pytest.raises(ValueError, match='bandwidth'):
+        gabor_kernel(0.1, bandwidth=-1, **sigma_kwargs)
+    with pytest.raises(ValueError, match='bandwidth'):
+        gabor_kernel(0.1, bandwidth=0, **sigma_kwargs)
+
+
+@pytest.mark.parametrize('bandwidth', [0, -1])
+def test_gabor_kernel_bandwidth_ignored_when_sigmas_given(bandwidth):
+    # The docstring says `bandwidth` is ignored when both sigmas are set, so the
+    # new guard must not fire there.
+    expected = gabor_kernel(0.1, sigma_x=1.0, sigma_y=1.0)
+    kernel = gabor_kernel(0.1, bandwidth=bandwidth, sigma_x=1.0, sigma_y=1.0)
+    assert_array_almost_equal(kernel, expected)
+
+
 @pytest.mark.parametrize('dtype', [np.complex64, np.complex128])
 def test_gabor_kernel_dtype(dtype):
     kernel = gabor_kernel(1, bandwidth=1, dtype=dtype)

--- a/tests/skimage2/filters/test_gabor.py
+++ b/tests/skimage2/filters/test_gabor.py
@@ -31,6 +31,38 @@ def test_gabor_kernel_bandwidth():
     assert_equal(kernel.shape, (9, 9))
 
 
+@pytest.mark.parametrize('bandwidth', [0, -0.5, -1])
+def test_gabor_kernel_invalid_bandwidth(bandwidth):
+    # `bandwidth=0` makes `_sigma_prefactor`'s denominator exactly zero, and a
+    # negative `bandwidth` makes it return a negative sigma, which is not a
+    # meaningful standard deviation. Both are rejected up front now.
+    with pytest.raises(ValueError, match='bandwidth'):
+        gabor_kernel(0.1, bandwidth=bandwidth)
+    with pytest.raises(ValueError, match='bandwidth'):
+        gabor(np.zeros((10, 10)), frequency=0.1, bandwidth=bandwidth)
+
+
+@pytest.mark.parametrize('sigma_kwargs', [{'sigma_x': 5.0}, {'sigma_y': 5.0}])
+def test_gabor_kernel_invalid_bandwidth_with_one_sigma(sigma_kwargs):
+    # Only one sigma is user-supplied, so the other is still derived from
+    # `bandwidth` and the guard must fire. Previously `bandwidth=-1` here left
+    # exactly one sigma negative, which flipped the sign of the whole kernel
+    # rather than cancelling out.
+    with pytest.raises(ValueError, match='bandwidth'):
+        gabor_kernel(0.1, bandwidth=-1, **sigma_kwargs)
+    with pytest.raises(ValueError, match='bandwidth'):
+        gabor_kernel(0.1, bandwidth=0, **sigma_kwargs)
+
+
+@pytest.mark.parametrize('bandwidth', [0, -1])
+def test_gabor_kernel_bandwidth_ignored_when_sigmas_given(bandwidth):
+    # The docstring says `bandwidth` is ignored when both sigmas are set, so the
+    # new guard must not fire there.
+    expected = gabor_kernel(0.1, sigma_x=1.0, sigma_y=1.0)
+    kernel = gabor_kernel(0.1, bandwidth=bandwidth, sigma_x=1.0, sigma_y=1.0)
+    assert_array_almost_equal(kernel, expected)
+
+
 @pytest.mark.parametrize('dtype', [np.complex64, np.complex128])
 def test_gabor_kernel_dtype(dtype):
     kernel = gabor_kernel(1, bandwidth=1, dtype=dtype)


### PR DESCRIPTION
### Summary

Fixes #8301 — `gabor_kernel` raised `ZeroDivisionError` for `bandwidth=0`, and silently accepted negative values.

### Root cause

`_sigma_prefactor` computes `(2**b + 1) / (2**b - 1)`. At `b = 0` the denominator is exactly zero. For `b < 0` it returns a negative sigma.

### On the negative case

I want to be precise here, because the obvious version of this claim is only half true.

When both sigmas are derived from `bandwidth`, the two negatives cancel in the `1 / (2 * pi * sigma_x * sigma_y)` normalisation, and the kernel comes out identical to the positive-bandwidth one. So on its own, a negative `bandwidth` is not observably wrong.

It does not cancel when the caller supplies exactly one sigma:

    gabor_kernel(0.1, bandwidth=-1, sigma_y=5.0)

Here `sigma_y` is positive and `sigma_x` is negative, so the product is negative. The result is an exact negation of the `bandwidth=+1` kernel (`max|k_neg + k_pos| == 0.0`), and the Gaussian envelope is negative everywhere. That silently inverts the sign of every downstream filter response.

### Fix

The guard is conditional on a sigma actually being missing, because the docstring states that `bandwidth` is ignored when both `sigma_x` and `sigma_y` are set. A check at the top of the function would reject input that the documentation currently promises is accepted.

Both `bandwidth` docstring entries now note that it must be greater than 0.

Tests are added to both `tests/skimage/filters/test_gabor.py` and `tests/skimage2/filters/test_gabor.py`, following the pattern in #8281 and #8288.

Thanks to @ravikumar266 for the report — the `_sigma_prefactor` diagnosis was correct; this extends it to the negative case and the both-sigmas carve-out.

### Testing

- Added three parametrized tests, mirrored into both test files.
- I could not build scikit-image locally on Windows, so CI is the judge on the full suite.
- I did confirm the new cases are not vacuous: against unpatched source they fail with `Failed: DID NOT RAISE <class 'ValueError'>`, and they pass with the guard in place.
- `ruff check` and `ruff format --diff` are clean on all three changed files.

### Note

Used an LLM for research assistance — reproducing the failure, checking whether a negative `bandwidth` actually changes the output (it does not, except in the one-sigma case above), and drafting the tests. I reviewed the diff line by line and verified the behaviour claims before submitting. The commit carries the required `Assisted-by:` trailer.

```release-note
`skimage.filters.gabor_kernel` and `skimage.filters.gabor` now raise a `ValueError` for non-positive `bandwidth`, instead of raising `ZeroDivisionError` (`bandwidth=0`) or silently deriving a negative sigma.
```
