### PR TITLE
Raise ValueError in SIFT when sigma_in >= sigma_min / upsampling

### DIFF
--- a/src/_skimage2/feature/sift.py
+++ b/src/_skimage2/feature/sift.py
@@ -118,7 +118,8 @@ class SIFT(FeatureDetector, DescriptorExtractor):
         The blur level of the seed image. If upsampling is enabled
         sigma_min is scaled by factor 1/upsampling
     sigma_in : float, optional
-        The assumed blur level of the input image.
+        The assumed blur level of the input image. Must not exceed
+        ``sigma_min / upsampling``.
     c_dog : float, optional
         Threshold to discard low contrast extrema in the DoG. It's final
         value is dependent on n_scales by the relation:
@@ -253,6 +254,8 @@ class SIFT(FeatureDetector, DescriptorExtractor):
         self.n_octaves = n_octaves
         self.n_scales = n_scales
         self.sigma_min = sigma_min / upsampling
+        if sigma_in > self.sigma_min:
+            raise ValueError("sigma_in must not exceed sigma_min / upsampling")
         self.sigma_in = sigma_in
         self.c_dog = (2 ** (1 / n_scales) - 1) / (2 ** (1 / 3) - 1) * c_dog
         self.c_edge = c_edge

--- a/tests/skimage2/feature/test_sift.py
+++ b/tests/skimage2/feature/test_sift.py
@@ -177,3 +177,22 @@ def test_no_descriptors_extracted_sift():
     detector_extractor = SIFT()
     with pytest.raises(RuntimeError):
         detector_extractor.detect_and_extract(img)
+
+
+def test_sift_sigma_in_exceeds_sigma_min_raises():
+    # Regression test: sigma_in > sigma_min / upsampling used to reach
+    # math.sqrt() with a negative argument inside _create_scalespace,
+    # raising an unhelpful ValueError/"math domain error" instead of a
+    # clear validation error. See gh-8303.
+    with pytest.raises(
+        ValueError, match="sigma_in must not exceed sigma_min / upsampling"
+    ):
+        SIFT(sigma_in=2.0)
+
+
+def test_sift_sigma_in_equal_to_sigma_min_is_valid():
+    # sigma_in == sigma_min / upsampling means zero additional blur is
+    # needed (sqrt(0) == 0), which is a valid, non-crashing configuration.
+    # This locks in that the boundary itself must not be rejected.
+    detector_extractor = SIFT(upsampling=1, sigma_min=1.6, sigma_in=1.6)
+    assert detector_extractor.sigma_in == 1.6


### PR DESCRIPTION
Fixes #8303 — SIFT raised an unhandled ValueError (or "math domain
error" on the released package) instead of a clear validation error
when sigma_in was set greater than sigma_min / upsampling.

Root cause
_create_scalespace computes the additional blur needed to reach the
seed level as math.sqrt(self.sigma_min**2 - self.sigma_in**2). This
combine-two-Gaussian-blurs formula only makes sense when
sigma_in <= sigma_min (after upsampling scaling). When sigma_in
exceeds it (e.g. sigma_in=2.0 with the default sigma_min=1.6,
upsampling=2 giving an effective sigma_min of 0.8), the value under
the square root goes negative.

Fix
Added an explicit validation check in SIFT.__init__, right after
self.sigma_min is computed:

if sigma_in > self.sigma_min:
    raise ValueError("sigma_in must not exceed sigma_min / upsampling")

Note the boundary is inclusive — sigma_in == sigma_min / upsampling
is valid, since it just means zero additional blur is needed
(sqrt(0) == 0). This was caught in review (thanks Copilot) and fixed
in a follow-up commit; the original version incorrectly rejected the
boundary case.

Also updated the sigma_in docstring entry to document the constraint.

Testing
Added two regression tests:
- test_sift_sigma_in_exceeds_sigma_min_raises — confirms a clean
  ValueError when sigma_in exceeds the limit
- test_sift_sigma_in_equal_to_sigma_min_is_valid — locks in that the
  boundary itself (sigma_in == sigma_min / upsampling) is accepted,
  not rejected
Confirmed default SIFT() still runs correctly on a real image
(data.camera()), finding keypoints as expected
Ran the full SIFT test suite locally — all tests pass
Ran doctests for the module — pass
Ran pre-commit run --all-files — all checks pass

Note
Used an LLM for research assistance during investigation. All
findings were independently verified locally before being acted on.