### PR TITLE
Fix pyramid_laplacian to build a reconstructable Laplacian pyramid

### DIFF
--- a/src/_skimage2/transform/pyramids.py
+++ b/src/_skimage2/transform/pyramids.py
@@ -301,15 +301,17 @@ def pyramid_laplacian(
     *,
     channel_axis=None,
 ):
-    """Yield images of the laplacian pyramid formed by the input image.
+    """Yield images of the Laplacian pyramid formed by the input image.
 
-    Each layer contains the difference between the downsampled and the
-    downsampled, smoothed image::
+    Each layer but the last is the difference between a Gaussian-pyramid level
+    and the next, coarser level upsampled back to its shape::
 
-        layer = resize(prev_layer) - smooth(resize(prev_layer))
+        layer_i = gaussian_i - expand(gaussian_{i + 1})
 
-    Note that the first image of the pyramid will be the difference between the
-    original, unscaled image and its smoothed version. The total number of
+    where ``expand`` upsamples and then smooths. The last layer is the smallest
+    Gaussian level itself (the low-frequency residual). Because of this, the
+    pyramid can rebuild the original image by successively upsampling the
+    coarsest layer and adding the finer layers back in. The total number of
     images is `max_layer + 1`. In case all layers are computed, the last image
     is either a one-pixel image or the image where the reduction does not
     change its shape.
@@ -367,42 +369,35 @@ def pyramid_laplacian(
         # automatically determine sigma which covers > 99% of distribution
         sigma = 2 * downscale / 6.0
 
-    current_shape = image.shape
+    # Gaussian pyramid levels G_0, G_1, ..., G_n. The image is already float, so
+    # keep its range to avoid a second conversion.
+    gaussian_layers = pyramid_gaussian(
+        image,
+        max_layer=max_layer,
+        downscale=downscale,
+        sigma=sigma,
+        order=order,
+        mode=mode,
+        cval=cval,
+        preserve_range=True,
+        channel_axis=channel_axis,
+    )
 
-    smoothed_image = _smooth(image, sigma, mode, cval, channel_axis)
-    yield image - smoothed_image
-
-    if channel_axis is not None:
-        channel_axis = channel_axis % image.ndim
-        shape_without_channels = list(current_shape)
-        shape_without_channels.pop(channel_axis)
-        shape_without_channels = tuple(shape_without_channels)
-    else:
-        shape_without_channels = current_shape
-
-    # build downsampled images until max_layer is reached or downscale process
-    # does not change image size
-    if max_layer == -1:
-        max_layer = math.ceil(math.log(max(shape_without_channels), downscale))
-
-    for layer in range(max_layer):
-        if channel_axis is not None:
-            out_shape = tuple(
-                math.ceil(d / float(downscale)) if ax != channel_axis else d
-                for ax, d in enumerate(current_shape)
-            )
-        else:
-            out_shape = tuple(math.ceil(d / float(downscale)) for d in current_shape)
-
-        resized_image = resize(
-            smoothed_image,
-            out_shape,
+    prev_layer = next(gaussian_layers)
+    for layer in gaussian_layers:
+        # ``expand`` the coarser Gaussian level back to the finer level's shape
+        # (upsample and smooth), then take the band-pass difference.
+        expanded = resize(
+            layer,
+            prev_layer.shape,
             order=order,
             mode=mode,
             cval=cval,
             anti_aliasing=False,
         )
-        smoothed_image = _smooth(resized_image, sigma, mode, cval, channel_axis)
-        current_shape = resized_image.shape
+        expanded = _smooth(expanded, sigma, mode, cval, channel_axis)
+        yield prev_layer - expanded
+        prev_layer = layer
 
-        yield resized_image - smoothed_image
+    # the smallest Gaussian level is the low-frequency residual
+    yield prev_layer

--- a/tests/skimage2/transform/test_pyramids.py
+++ b/tests/skimage2/transform/test_pyramids.py
@@ -187,6 +187,28 @@ def test_laplacian_pyramid_max_layers(channel_axis):
         assert out_shape_without_channels == (1, 1)
 
 
+def test_laplacian_pyramid_reconstruction():
+    # A Laplacian pyramid must rebuild the original image by successively
+    # upsampling the coarsest layer and adding the finer layers back in.
+    # Regression test for gh-7921.
+    rng = np.random.default_rng(0)
+    image = rng.random((40, 40))
+    downscale = 2
+    sigma = 2 * downscale / 6.0
+
+    layers = list(pyramids.pyramid_laplacian(image, downscale=downscale))
+
+    reconstructed = layers[-1]
+    for layer in reversed(layers[:-1]):
+        expanded = pyramids.resize(
+            reconstructed, layer.shape, mode='reflect', anti_aliasing=False
+        )
+        expanded = pyramids._smooth(expanded, sigma, 'reflect', 0, None)
+        reconstructed = expanded + layer
+
+    assert_almost_equal(reconstructed, image)
+
+
 def test_check_factor():
     with pytest.raises(ValueError):
         pyramids._check_factor(0.99)


### PR DESCRIPTION
#### Description

`pyramid_laplacian` did not follow the cited Burt & Adelson paper: each layer was `G_i - smooth(G_i)` (a same-resolution high-pass) with no low-frequency residual, so the pyramid could not reconstruct the original image (#7921).

This rewrites it as a proper Laplacian pyramid: `layer_i = G_i - expand(G_{i+1})` (upsample the coarser Gaussian level back to the finer level's shape and smooth), and the final layer is the smallest Gaussian level (the low-frequency residual). Reconstruction now telescopes back to the input.

#### Verification

Added `test_laplacian_pyramid_reconstruction`. Reconstruction error is ~1e-16 (machine precision) for grayscale, color, and non-square inputs, versus ~0.8 before the fix. Level counts and layer shapes are unchanged, so the existing shape/count tests still pass. `ruff check`/`format` are clean.

Note: I was unable to build scikit-image locally to run the full pytest suite (meson/Cython build issue on my machine), so I validated the algorithm against the real `pyramid_gaussian`/`resize`/`_smooth` helpers and the level-count invariants; CI will run the suite.

#### AI disclosure

Per the project's AI policy, this change was drafted with AI assistance (Claude) and reviewed line-by-line by the human contributor; the commit carries an `Assisted-by:` tag. Happy to discuss the approach in detail.

Closes #7921