### PR TITLE
Bump kaleido to >=1.0 and provision Chrome for doc builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,22 @@ jobs:
             python3 -m pip install -r requirements/docs.txt
       - run:
           name: Install Chrome for kaleido
+          # See .github/workflows/test-docs.yaml for why this installs
+          # Chrome through apt instead of `plotly_get_chrome`. This machine
+          # image already has a google-chrome apt source configured under a
+          # different (or no) Signed-By, so only add our own if none exists;
+          # a second, conflicting definition for the same repo breaks `apt-get
+          # update` outright ("Conflicting values set for option Signed-By").
           command: |
-            plotly_get_chrome -y
+            if ! grep -qr "dl.google.com/linux/chrome/deb" /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null; then
+              wget -q -O - https://dl.google.com/linux/linux_signing_key.pub \
+                | gpg --dearmor \
+                | sudo tee /usr/share/keyrings/google-chrome.gpg >/dev/null
+              echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
+                | sudo tee /etc/apt/sources.list.d/google-chrome.list
+            fi
+            sudo apt-get update
+            sudo apt-get install -y google-chrome-stable
       - run:
           name: Print ccache performance
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,17 +37,20 @@ jobs:
             python3 -m pip install -r requirements/docs.txt
       - run:
           name: Install Chrome for kaleido
-          # See .github/workflows/test-docs.yaml for why this installs
-          # Chrome through apt instead of `plotly_get_chrome`. Installing
-          # the downloaded .deb directly, rather than adding Google's apt
-          # repo, avoids this machine image's own preconfigured
-          # google-chrome source, whose Signed-By conflicts with one we'd
-          # add ("Conflicting values set for option Signed-By").
+          # Installs via apt like test-docs.yaml (see there for why). This
+          # image preconfigures a google-chrome source without Signed-By,
+          # which conflicts with the signed one below, so remove it first.
           command: |
-            wget -q -O google-chrome-stable.deb \
-              https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.list; do
+              [ -f "$f" ] && sudo sed -i '\#dl\.google\.com/linux/chrome/deb#d' "$f"
+            done
+            wget -q -O - https://dl.google.com/linux/linux_signing_key.pub \
+              | gpg --dearmor \
+              | sudo tee /usr/share/keyrings/google-chrome.gpg >/dev/null
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
+              | sudo tee /etc/apt/sources.list.d/google-chrome.list
             sudo apt-get update
-            sudo apt-get install -y ./google-chrome-stable.deb
+            sudo apt-get install -y google-chrome-stable
       - run:
           name: Print ccache performance
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,10 @@ jobs:
             python3 -m pip install -r requirements/default.txt
             python3 -m pip install -r requirements/docs.txt
       - run:
+          name: Install Chrome for kaleido
+          command: |
+            plotly_get_chrome -y
+      - run:
           name: Print ccache performance
           command: |
             ccache -s

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,21 +38,16 @@ jobs:
       - run:
           name: Install Chrome for kaleido
           # See .github/workflows/test-docs.yaml for why this installs
-          # Chrome through apt instead of `plotly_get_chrome`. This machine
-          # image already has a google-chrome apt source configured under a
-          # different (or no) Signed-By, so only add our own if none exists;
-          # a second, conflicting definition for the same repo breaks `apt-get
-          # update` outright ("Conflicting values set for option Signed-By").
+          # Chrome through apt instead of `plotly_get_chrome`. Installing
+          # the downloaded .deb directly, rather than adding Google's apt
+          # repo, avoids this machine image's own preconfigured
+          # google-chrome source, whose Signed-By conflicts with one we'd
+          # add ("Conflicting values set for option Signed-By").
           command: |
-            if ! grep -qr "dl.google.com/linux/chrome/deb" /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null; then
-              wget -q -O - https://dl.google.com/linux/linux_signing_key.pub \
-                | gpg --dearmor \
-                | sudo tee /usr/share/keyrings/google-chrome.gpg >/dev/null
-              echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
-                | sudo tee /etc/apt/sources.list.d/google-chrome.list
-            fi
+            wget -q -O google-chrome-stable.deb \
+              https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
             sudo apt-get update
-            sudo apt-get install -y google-chrome-stable
+            sudo apt-get install -y ./google-chrome-stable.deb
       - run:
           name: Print ccache performance
           command: |

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -45,6 +45,8 @@ jobs:
         # arm64 Chrome, at the same version Chrome for Testing is missing for
         # that architecture, and choreographer's browser search checks
         # /usr/bin/google-chrome-stable before falling back to a download.
+        # CircleCI's docs job installs Chrome the same way, since
+        # `plotly_get_chrome`'s console script isn't reliably on PATH there.
         run: |
           wget -q -O - https://dl.google.com/linux/linux_signing_key.pub \
             | gpg --dearmor \

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -37,6 +37,23 @@ jobs:
         run: |
           source .github/scripts/setup-docs-env.sh
 
+      - name: Install Chrome for kaleido
+        # Neither kaleido's own `plotly_get_chrome` nor browser-actions/setup-chrome
+        # can provision Chrome here: both fetch from Chrome for Testing, which
+        # doesn't yet publish a Stable-channel linux-arm64 build, and this job
+        # runs on an arm64 runner. Google's separate apt repository does ship
+        # arm64 Chrome, at the same version Chrome for Testing is missing for
+        # that architecture, and choreographer's browser search checks
+        # /usr/bin/google-chrome-stable before falling back to a download.
+        run: |
+          wget -q -O - https://dl.google.com/linux/linux_signing_key.pub \
+            | gpg --dearmor \
+            | sudo tee /usr/share/keyrings/google-chrome.gpg >/dev/null
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
+            | sudo tee /etc/apt/sources.list.d/google-chrome.list
+          sudo apt-get update
+          sudo apt-get install -y google-chrome-stable
+
       - name: Build docs / run examples
         run: |
           SPHINXCACHE=${HOME}/.cache/sphinx SPHINXOPTS="-W -j auto" make -C doc html

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -38,15 +38,10 @@ jobs:
           source .github/scripts/setup-docs-env.sh
 
       - name: Install Chrome for kaleido
-        # Neither kaleido's own `plotly_get_chrome` nor browser-actions/setup-chrome
-        # can provision Chrome here: both fetch from Chrome for Testing, which
-        # doesn't yet publish a Stable-channel linux-arm64 build, and this job
-        # runs on an arm64 runner. Google's separate apt repository does ship
-        # arm64 Chrome, at the same version Chrome for Testing is missing for
-        # that architecture, and choreographer's browser search checks
-        # /usr/bin/google-chrome-stable before falling back to a download.
-        # CircleCI's docs job installs Chrome the same way, since
-        # `plotly_get_chrome`'s console script isn't reliably on PATH there.
+        # plotly_get_chrome and browser-actions/setup-chrome fetch from Chrome
+        # for Testing, which has no Stable-channel linux-arm64 build (this
+        # runner is arm64). Google's apt repo does have arm64 Chrome, and
+        # choreographer checks /usr/bin/google-chrome-stable before downloading.
         run: |
           wget -q -O - https://dl.google.com/linux/linux_signing_key.pub \
             | gpg --dearmor \

--- a/environment.yml
+++ b/environment.yml
@@ -43,7 +43,7 @@ dependencies:
   - ipywidgets
   - ipykernel
   - plotly>=5.20
-  - python-kaleido==0.2.1
+  - python-kaleido>=1.0
   - scikit-learn>=1.6
   - sphinx-design>=0.5
   - pydata-sphinx-theme>=0.16

--- a/environment.yml
+++ b/environment.yml
@@ -42,7 +42,7 @@ dependencies:
   - intersphinx-registry>=0.2411.14
   - ipywidgets
   - ipykernel
-  - plotly>=5.20
+  - plotly>=6.1.1
   - python-kaleido>=1.0
   - scikit-learn>=1.6
   - sphinx-design>=0.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ docs = [
     'ipywidgets',
     'ipykernel',  # needed until https://github.com/jupyter-widgets/ipywidgets/issues/3731 is resolved
     'plotly>=5.20',
-    'kaleido==0.2.1',
+    'kaleido>=1.0',
     'scikit-learn>=1.6',
     'sphinx_design>=0.5',
     'pydata-sphinx-theme>=0.16',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ docs = [
     'intersphinx-registry>=0.2411.14',
     'ipywidgets',
     'ipykernel',  # needed until https://github.com/jupyter-widgets/ipywidgets/issues/3731 is resolved
-    'plotly>=5.20',
+    'plotly>=6.1.1',
     'kaleido>=1.0',
     'scikit-learn>=1.6',
     'sphinx_design>=0.5',

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -15,7 +15,7 @@ myst-parser
 intersphinx-registry>=0.2411.14
 ipywidgets
 ipykernel
-plotly>=5.20
+plotly>=6.1.1
 kaleido>=1.0
 scikit-learn>=1.6
 sphinx_design>=0.5

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -16,7 +16,7 @@ intersphinx-registry>=0.2411.14
 ipywidgets
 ipykernel
 plotly>=5.20
-kaleido==0.2.1
+kaleido>=1.0
 scikit-learn>=1.6
 sphinx_design>=0.5
 pydata-sphinx-theme>=0.16


### PR DESCRIPTION
Fixes #8307. Closes #7623.

plotly 7.0.0 dropped support for kaleido 0.2.1, breaking every gallery example that calls `plotly.io.show(fig)`. kaleido's 1.x rewrite needs both a plotly>=6.1.1 floor and a headless Chrome install, which each CI docs job now provides.

### Changes

- Bumped `kaleido` from `==0.2.1` to `>=1.0`, so gallery examples render through headless Chrome instead of the deprecated bundled binary.
- Bumped `plotly` from `>=5.20` to `>=6.1.1`, kaleido's own hardcoded floor for compatibility with 1.x.
- The GitHub Actions docs job installs Chrome through apt: it runs on arm64, where neither `plotly_get_chrome` nor `browser-actions/setup-chrome` can provision Chrome (Chrome for Testing has no Stable-channel linux-arm64 build yet).
- CircleCI's docs job installs Chrome through apt too, since `plotly_get_chrome`'s console script isn't reliably on PATH there.

### Testing

Docs CI tests.

### Release note (optional)

<!-- See https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes -->

```release-note
...
```
