### PR TITLE
Document the intentional fixed seed in restoration regression tests

### DIFF
--- a/tests/skimage/restoration/test_restoration.py
+++ b/tests/skimage/restoration/test_restoration.py
@@ -34,7 +34,8 @@ def test_wiener(dtype, ndim, test_root_dir):
     precomputed result in 2d case.
     """
 
-    # fails with other seeds?
+    # seed fixed for compatibility with the stored reference data
+    # (camera_wiener.npy) compared against in the ndim == 2 case below
     rng = np.random.RandomState(0)
     psf = np.ones([5] * ndim, dtype=dtype) / 5**ndim
 
@@ -148,7 +149,8 @@ def test_image_shape():
 @pytest.mark.parametrize('ndim', [1, 2, 3])
 def test_richardson_lucy(ndim, test_root_dir):
     psf = np.ones([5] * ndim, dtype=float) / 5**ndim
-    # fails with different seeds?
+    # seed fixed for compatibility with the stored reference data
+    # (camera_rl.npy) compared against in the ndim == 2 case below
     rng = np.random.RandomState(0)
     if ndim != 2:
         test_img = rng.randint(0, 100, [30] * ndim)

--- a/tests/skimage2/restoration/test_restoration.py
+++ b/tests/skimage2/restoration/test_restoration.py
@@ -34,7 +34,8 @@ def test_wiener(dtype, ndim, test_root_dir):
     precomputed result in 2d case.
     """
 
-    # fails with other seeds?
+    # seed fixed for compatibility with the stored reference data
+    # (camera_wiener.npy) compared against in the ndim == 2 case below
     rng = np.random.RandomState(0)
     psf = np.ones([5] * ndim, dtype=dtype) / 5**ndim
 
@@ -148,7 +149,8 @@ def test_image_shape():
 @pytest.mark.parametrize('ndim', [1, 2, 3])
 def test_richardson_lucy(ndim, test_root_dir):
     psf = np.ones([5] * ndim, dtype=float) / 5**ndim
-    # fails with different seeds?
+    # seed fixed for compatibility with the stored reference data
+    # (camera_rl.npy) compared against in the ndim == 2 case below
     rng = np.random.RandomState(0)
     if ndim != 2:
         test_img = rng.randint(0, 100, [30] * ndim)


### PR DESCRIPTION
Closes #8130.

### What

`test_wiener` and `test_richardson_lucy` in `test_restoration.py` pin
`np.random.RandomState(0)`, each above an uncertain `# fails with ... seeds?`
comment. This replaces those markers with a comment that explains the seed is
fixed on purpose.

### Why

In both tests, the `ndim == 2` branch compares the deconvolved output against a
stored reference array (`camera_wiener.npy`, `camera_rl.npy`) computed with the
seed-0 noise realization. A different seed produces different noise, so a
different but still valid deconvolution, so the exact-value `assert_allclose`
against the seed-0 reference fails. That is the expected behavior of a
stored-reference regression test, not a numerical instability in `wiener` or
`richardson_lucy`. The `ndim != 2` branches don't compare against a stored
reference and can't be seed-sensitive.

This came out of #8084, where these tests were noted to fail for seeds other
than 0. The free-threading goal behind #8084 (removing the shared global RNG
stream that concurrent threads corrupt) is already met here by a local seeded
`RandomState` at any fixed seed; the seed value itself doesn't affect thread
safety.

The new comment mirrors the existing note a few lines up in
`test_unsupervised_wiener`, which already documents its own fixed seed "for
compatibility with previously stored reference data."

### Scope

Comments only, mirrored across both test trees (`tests/skimage/` and
`tests/skimage2/`). No change to the seed, RNG type, assertions, tolerances, or
the reference `.npy` files, and no change to the restoration source.

I raised this as Direction A in a check-in on #8130 and offered a Direction B
there (rewrite the `ndim == 2` case to assert a seed-invariant property instead
of comparing to a stored array, which would pass for any seed but drops the
exact-output regression check and needs the references regenerated). Happy to
switch to B if you'd prefer.
