### PR TITLE
Use non-interactive Agg backend for Windows test jobs

### DIFF
--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -15,6 +15,9 @@ env:
   CC: ccache clang
   CXX: ccache clang
   CCACHE_DIR: C:\ccache
+  # Hosted Windows runners intermittently ship an unreadable Tcl install, so
+  # matplotlib's default TkAgg backend fails; see gh-8194.
+  MPLBACKEND: Agg
 
 jobs:
   test_skimage_windows:


### PR DESCRIPTION
AI-policy - this was generated by Cursor using Claude-5.   I didn't ask it to create this PR - but I did check the change - which is trivial, and matched my instructions.   Description is also correct.

### Description

GitHub's hosted Windows runners intermittently provide a Python whose Tcl files cannot be read, so any test that instantiates matplotlib's default `TkAgg` backend fails:

```
E       _tkinter.TclError: Can't find a usable init.tcl in the following directories:
E           {C:\hostedtoolcache\windows\Python\3.12.10\x64\tcl\tcl8.6}
E
E       C:/hostedtoolcache/windows/Python/3.12.10/x64/tcl/tcl8.6/init.tcl: couldn't read file "...": No error
```

In practice this shows up as `tests/skimage/filters/test_thresholding.py::TestSimpleImage::test_try_all_threshold` failing in the `windows-cp3.12-optional-deps` job, and it passes on re-run.

This is a known runner problem rather than a matplotlib or scikit-image bug:

- gh-8194 recorded it on `main` in May, with the identical traceback.
- [actions/setup-python#1102](https://github.com/actions/setup-python/issues/1102) collects the same report from many projects across Python 3.10–3.13; GitHub could not reproduce it and closed it.
- [matplotlib#29119](https://github.com/matplotlib/matplotlib/issues/29119) — "It's probably a runner bug; they don't really check that Tk works... you should set the backend to Agg."
- [brainglobe-heatmap#98](https://github.com/brainglobe/brainglobe-heatmap/issues/98) worked around it the same way.

### Changes

- Set `MPLBACKEND: Agg` for the Windows test workflow. None of the tests need a GUI, and docs builds already sidestep this by writing a `Template` backend in `.github/scripts/setup-docs-env.sh`.

If maintainers prefer, the same variable could be set for the Linux and macOS workflows for consistency; only Windows is known to hit this.

### Testing

CI on this PR.

Closes gh-8194.
