### PR TITLE
Generalize matrix_transform docstring

### DIFF
--- a/src/_skimage2/transform/_geometric.py
+++ b/src/_skimage2/transform/_geometric.py
@@ -2664,12 +2664,12 @@ def estimate_transform(ttype, src, dst, *args, **kwargs):
 
 
 def matrix_transform(coords, matrix):
-    """Apply 2D matrix transform.
+    """Apply 2D matrix transform to coordinates.
 
     Parameters
     ----------
     coords : array_like of shape (N, 2)
-        x, y coordinates to transform
+        Coordinates to transform
     matrix : array_like of shape (3, 3)
         Homogeneous transformation matrix.
 
@@ -2677,6 +2677,5 @@ def matrix_transform(coords, matrix):
     -------
     coords : ndarray of shape (N, 2)
         Transformed coordinates.
-
     """
     return ProjectiveTransform(matrix)(coords)


### PR DESCRIPTION
We are moving towards generalizing the Transform instances to operate on
2D coordinate arrays, where the meaning (in terms of x, y, or r, c) is
up to the user.  In that case, x, y in the docstring is a needless
confusion.
