### PR TITLE
Add implicit NaN mask

### DIFF
--- a/src/_skimage2/restoration/unwrap.py
+++ b/src/_skimage2/restoration/unwrap.py
@@ -20,7 +20,10 @@ def unwrap_phase(image, wrap_around=False, rng=None):
         provided, the masked entries will not be changed, and their values
         will not be used to guide the unwrapping of neighboring, unmasked
         values. Masked 1D arrays are not allowed, and will raise a
-        `ValueError`.
+        `ValueError`.  NaN values in the image form an implicit mask.  We
+        combine this implicit mask with any mask from a masked array, with
+        logical OR.  The output values under the resulting mask are set to the
+        minimum of the unwrapped phase.
     wrap_around : bool or sequence of bool, optional
         When an element of the sequence is  `True`, the unwrapping process
         will regard the edges along the corresponding axis of the image to be
@@ -96,9 +99,16 @@ def unwrap_phase(image, wrap_around=False, rng=None):
             '`wrap_around` must be a bool or a sequence with '
             'length equal to the dimensionality of image'
         )
+
+    # NaNs form an implicit mask.
+    nan_mask = np.isnan(image)
+    any_nans = np.any(nan_mask)
+
     if image.ndim == 1:
         if np.ma.isMaskedArray(image):
             raise ValueError('1D masked images cannot be unwrapped')
+        if any_nans:
+            raise ValueError('1D images with NaNs cannot be unwrapped')
         if wrap_around[0]:
             raise ValueError('`wrap_around` is not supported for 1D images')
     if image.ndim in (2, 3) and 1 in image.shape:
@@ -112,11 +122,13 @@ def unwrap_phase(image, wrap_around=False, rng=None):
         rng = np.random.default_rng(rng)
 
     if np.ma.isMaskedArray(image):
-        mask = np.require(np.ma.getmaskarray(image), np.uint8, ['C'])
+        mask = nan_mask | np.require(np.ma.getmaskarray(image), np.uint8, ['C'])
     else:
-        mask = np.zeros_like(image, dtype=np.uint8, order='C')
+        mask = nan_mask
 
     image_not_masked = np.asarray(np.ma.getdata(image), dtype=np.float64, order='C')
+    if any_nans:
+        image_not_masked[nan_mask] = 0
     image_unwrapped = np.empty_like(image, dtype=np.float64, order='C', subok=False)
 
     if image.ndim == 1:

--- a/tests/skimage/restoration/test_unwrap.py
+++ b/tests/skimage/restoration/test_unwrap.py
@@ -53,8 +53,13 @@ def test_unwrap_1d():
     image = np.linspace(0, 10 * np.pi, 100)
     check_unwrap(image)
     # Masked arrays are not allowed in 1D
-    with testing.raises(ValueError):
+    with testing.raises(ValueError, match='1D masked images cannot'):
         check_unwrap(image, True)
+    # Arrays with NaN not allowed in 1D
+    nan_image = image.copy()
+    nan_image[50] = np.nan
+    with testing.raises(ValueError, match='1D images with NaNs cannot'):
+        check_unwrap(nan_image, None)
     # wrap_around is not allowed in 1D
     with testing.raises(ValueError):
         unwrap_phase(image, True, rng=0)
@@ -71,6 +76,19 @@ def test_unwrap_2d(check_with_mask):
     check_unwrap(image, mask)
 
 
+def test_unwrap_2d_nan():
+    x, y = np.ogrid[:8, :16]
+    image = 2 * np.pi * (x * 0.2 + y * 0.1)
+    image_wrapped = np.angle(np.exp(1j * image))
+    mask = np.zeros(image.shape, dtype=bool)
+    mask[4:6, 4:8] = True
+    image_wrapped_masked = np.ma.array(image_wrapped, mask=mask, fill_value=0.5)
+    mask_res = unwrap_phase(image_wrapped_masked, rng=0)
+    image_wrapped_nans = image_wrapped.copy()
+    image_wrapped_nans[mask] = np.nan
+    np.testing.assert_equal(mask_res, unwrap_phase(image_wrapped_nans, rng=0))
+
+
 @testing.parametrize("check_with_mask", (False, True))
 def test_unwrap_3d(check_with_mask):
     mask = None
@@ -80,6 +98,20 @@ def test_unwrap_3d(check_with_mask):
         mask = np.zeros(image.shape, dtype=bool)
         mask[4:6, 4:6, 1:3] = True
     check_unwrap(image, mask)
+
+
+def test_unwrap_3d_nan():
+    x, y, z = np.ogrid[:8, :12, :16]
+    image = 2 * np.pi * (x * 0.2 + y * 0.1 + z * 0.05)
+    image_wrapped = np.angle(np.exp(1j * image))
+    mask = np.zeros(image.shape, dtype=bool)
+    mask[4:6, 4:6, 1:3] = True
+    image_wrapped_masked = np.ma.array(image_wrapped, mask=mask, fill_value=0.5)
+    mask_res = unwrap_phase(image_wrapped_masked, rng=0)
+    image_wrapped_nans = image_wrapped.copy()
+    image_wrapped_nans[mask] = np.nan
+    masked_nan = unwrap_phase(image_wrapped_nans, rng=0)
+    np.testing.assert_equal(mask_res, masked_nan)
 
 
 def check_wrap_around(ndim, axis):

--- a/tests/skimage2/restoration/test_unwrap.py
+++ b/tests/skimage2/restoration/test_unwrap.py
@@ -53,8 +53,13 @@ def test_unwrap_1d():
     image = np.linspace(0, 10 * np.pi, 100)
     check_unwrap(image)
     # Masked arrays are not allowed in 1D
-    with testing.raises(ValueError):
+    with testing.raises(ValueError, match='1D masked images cannot'):
         check_unwrap(image, True)
+    # Arrays with NaN not allowed in 1D
+    nan_image = image.copy()
+    nan_image[50] = np.nan
+    with testing.raises(ValueError, match='1D images with NaNs cannot'):
+        check_unwrap(nan_image, None)
     # wrap_around is not allowed in 1D
     with testing.raises(ValueError):
         unwrap_phase(image, True, rng=0)
@@ -71,6 +76,19 @@ def test_unwrap_2d(check_with_mask):
     check_unwrap(image, mask)
 
 
+def test_unwrap_2d_nan():
+    x, y = np.ogrid[:8, :16]
+    image = 2 * np.pi * (x * 0.2 + y * 0.1)
+    image_wrapped = np.angle(np.exp(1j * image))
+    mask = np.zeros(image.shape, dtype=bool)
+    mask[4:6, 4:8] = True
+    image_wrapped_masked = np.ma.array(image_wrapped, mask=mask, fill_value=0.5)
+    mask_res = unwrap_phase(image_wrapped_masked, rng=0)
+    image_wrapped_nans = image_wrapped.copy()
+    image_wrapped_nans[mask] = np.nan
+    np.testing.assert_equal(mask_res, unwrap_phase(image_wrapped_nans, rng=0))
+
+
 @testing.parametrize("check_with_mask", (False, True))
 def test_unwrap_3d(check_with_mask):
     mask = None
@@ -80,6 +98,20 @@ def test_unwrap_3d(check_with_mask):
         mask = np.zeros(image.shape, dtype=bool)
         mask[4:6, 4:6, 1:3] = True
     check_unwrap(image, mask)
+
+
+def test_unwrap_3d_nan():
+    x, y, z = np.ogrid[:8, :12, :16]
+    image = 2 * np.pi * (x * 0.2 + y * 0.1 + z * 0.05)
+    image_wrapped = np.angle(np.exp(1j * image))
+    mask = np.zeros(image.shape, dtype=bool)
+    mask[4:6, 4:6, 1:3] = True
+    image_wrapped_masked = np.ma.array(image_wrapped, mask=mask, fill_value=0.5)
+    mask_res = unwrap_phase(image_wrapped_masked, rng=0)
+    image_wrapped_nans = image_wrapped.copy()
+    image_wrapped_nans[mask] = np.nan
+    masked_nan = unwrap_phase(image_wrapped_nans, rng=0)
+    np.testing.assert_equal(mask_res, masked_nan)
 
 
 def check_wrap_around(ndim, axis):


### PR DESCRIPTION
Fixes #3831.

Mask any NaNs in the image.

This is a more general fix than in https://github.com/scikit-image/scikit-image/pull/7176.

Co-authored-by: Lars Grüter <lagru+github@mailbox.org>

--
Ported from #8193 on pre-megamove-integration (af098de)
Assisted-by: claude-code:claude-opus-5
