### PR TITLE
DOC: note radians where missing, or incorrect

### DIFF
--- a/src/_skimage2/draw/draw.py
+++ b/src/_skimage2/draw/draw.py
@@ -66,8 +66,9 @@ def ellipse(r, c, r_radius, c_radius, shape=None, rotation=0.0):
         By default the full extent of the ellipse are used. Must be at least
         length 2. Only the first two values are used to determine the extent.
     rotation : float, optional (default 0.)
-        Set the ellipse rotation (rotation) in range (-PI, PI)
-        in contra clock wise direction, so PI/2 degree means swap ellipse axis
+        Set the ellipse rotation counter-clockwise, in radians.  An ellipse
+        is symmetric under a half turn, so a rotation of PI/2 swaps the
+        ellipse axes.
 
     Returns
     -------
@@ -121,7 +122,8 @@ def ellipse(r, c, r_radius, c_radius, shape=None, rotation=0.0):
 
     center = np.array([r, c])
     radii = np.array([r_radius, c_radius])
-    # allow just rotation with in range +/- 180 degree
+    # An ellipse is symmetric under a half turn, so fold the rotation, in
+    # radians, into [0, PI).
     rotation %= np.pi
 
     # compute rotated radii by given rotation

--- a/src/_skimage2/feature/texture.py
+++ b/src/_skimage2/feature/texture.py
@@ -221,7 +221,7 @@ def graycoprops(P, prop='contrast'):
     Examples
     --------
     Compute the contrast for GLCMs with distances [1, 2] and angles
-    [0 degrees, 90 degrees]
+    [0, pi/2] radians
 
     >>> image = np.array([[0, 0, 1, 1],
     ...                   [0, 0, 1, 1],

--- a/src/_skimage2/filters/_gabor.py
+++ b/src/_skimage2/filters/_gabor.py
@@ -46,8 +46,8 @@ def gabor_kernel(
     sigma_x, sigma_y : float, optional
         Standard deviation in x- and y-directions. These directions apply to
         the kernel *before* rotation. If `theta = pi/2`, then the kernel is
-        rotated 90 degrees so that ``sigma_x`` controls the *vertical*
-        direction.
+        rotated by pi/2 radians (90 degrees) so that ``sigma_x`` controls the
+        *vertical* direction.
     n_stds : scalar, optional
         The linear size of the kernel is n_stds (3 by default) standard
         deviations
@@ -151,8 +151,8 @@ def gabor(
     sigma_x, sigma_y : float, optional
         Standard deviation in x- and y-directions. These directions apply to
         the kernel *before* rotation. If ``theta = pi/2``, then the kernel is
-        rotated 90 degrees so that `sigma_x` controls the *vertical*
-        direction.
+        rotated by pi/2 radians (90 degrees) so that `sigma_x` controls the
+        *vertical* direction.
     n_stds : scalar, optional
         The linear size of the kernel is n_stds (3 by default) standard
         deviations.

--- a/src/_skimage2/measure/fit.py
+++ b/src/_skimage2/measure/fit.py
@@ -737,7 +737,7 @@ class EllipseModel(_BaseModel):
         Length of first axis and length of second axis.  Call these ``a`` and
         ``b``.
     theta : float
-        Angle of first axis.
+        Angle of first axis, in radians.
 
     Raises
     ------
@@ -795,7 +795,7 @@ class EllipseModel(_BaseModel):
             Length of first axis and length of second axis.  Call these ``a``
             and ``b``.
         theta : float
-            Angle of first axis.
+            Angle of first axis, in radians.
         """
         self.center, self.axis_lengths, self.theta = self._check_init_values(
             center, axis_lengths, theta

--- a/src/_skimage2/transform/_geometric.py
+++ b/src/_skimage2/transform/_geometric.py
@@ -943,7 +943,7 @@ class ProjectiveTransform(_HMatrixTransform):
        [b0 b1 b2]
        [c0 c1 1 ]].
 
-    E.g., to rotate by theta degrees clockwise, the matrix should be::
+    E.g., to rotate by theta radians clockwise, the matrix should be::
 
       [[cos(theta) -sin(theta) 0]
        [sin(theta)  cos(theta) 0]

--- a/src/_skimage2/transform/_warps.py
+++ b/src/_skimage2/transform/_warps.py
@@ -559,7 +559,7 @@ def swirl(
         The extent of the swirl in pixels.  The effect dies out
         rapidly beyond `radius`.
     rotation : float, optional
-        Additional rotation applied to the image.
+        Additional rotation applied to the image, in radians.
 
     Returns
     -------

--- a/src/_skimage2/transform/_warps_cy.pyx
+++ b/src/_skimage2/transform/_warps_cy.pyx
@@ -78,7 +78,7 @@ def _warp_fast(np_floats[:, :] image, np_floats[:, :] H, output_shape=None,
     For each pixel, given its homogeneous coordinate :math:`\mathbf{x}
     = [x, y, 1]^T`, its target position is calculated by multiplying
     with the given matrix, :math:`H`, to give :math:`H \mathbf{x}`.
-    E.g., to rotate by theta degrees clockwise, the matrix should be::
+    E.g., to rotate by theta radians clockwise, the matrix should be::
 
       [[cos(theta) -sin(theta) 0]
        [sin(theta)  cos(theta) 0]


### PR DESCRIPTION
In docstrings, note that input argument or similar is in fact in
radians, not degrees.  Or add "in radians" to inputs where radians not
stated (but where this is the case).

Changes initially made by Claude code during investigation.  Checked and
edited by me.  Commit / PR message by me.

Assisted-by: Claude Opus 5 (Claude Code)
